### PR TITLE
fix: add permissions blocks to GitHub Actions workflows

### DIFF
--- a/.github/workflows/validate-merged.yml
+++ b/.github/workflows/validate-merged.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths: ['k8s/**', 'scripts/**']
 
+permissions:
+  contents: read
+
 jobs:
   validate-current-and-recent:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     paths: ['k8s/**', 'scripts/**', 'Makefile', '.pre-commit-config.yaml']
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Fixes CodeQL alerts #1, #2, #3: `actions/missing-workflow-permissions`
- Adds `permissions: contents: read` at the workflow level to `validate.yml` and `validate-merged.yml`
- Both workflows are read-only (checkout, kustomize build, schema validation) and only require `contents: read`

## Test plan

- [ ] Verify CodeQL re-scan clears all 3 alerts after merge
- [ ] Confirm CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `permissions: contents: read` to GitHub Actions workflows to fix CodeQL alerts.
> 
>   - **Permissions**:
>     - Adds `permissions: contents: read` to `validate.yml` and `validate-merged.yml` to address CodeQL alerts `actions/missing-workflow-permissions`.
>   - **Workflows**:
>     - Both workflows are read-only, performing operations like checkout, kustomize build, and schema validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fkubernetes-monitoring&utm_source=github&utm_medium=referral)<sup> for 9dd094d218bd5ad49e5ad9dfb437a513e2a34078. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->