### PR TITLE
chore: group Renovate updates and automerge GHA/pre-commit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,15 +4,16 @@
   "packageRules": [
     {
       "description": "Group all dependency updates into a single PR",
-      "matchPackagePatterns": ["*"],
+      "matchPackagePatterns": [".*"],
       "groupName": "all dependencies",
       "groupSlug": "all-dependencies"
     },
     {
       "description": "Automerge official GitHub Actions (including major)",
-      "matchDatasources": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "matchPackagePrefixes": ["actions/"],
       "groupName": "github-actions",
+      "groupSlug": "github-actions",
       "automerge": true,
       "automergeType": "squash"
     },
@@ -21,6 +22,7 @@
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "pre-commit hooks",
+      "groupSlug": "pre-commit-hooks",
       "automerge": true,
       "automergeType": "squash"
     }


### PR DESCRIPTION
## Summary

- Replace bare `config:recommended` with `packageRules` that group all dependency updates into a single PR
- Add automerge for official `actions/*` GitHub Actions updates (including major version bumps)
- Add automerge for pre-commit hook minor/patch updates

**Expected result**: At most 3 PRs from Renovate instead of N individual ones:
- `github-actions` group → auto-merged
- `pre-commit hooks` group → auto-merged (minor/patch only)
- `all dependencies` group → one grouped PR for manual review

## Test plan

- [ ] Merge this PR
- [ ] Wait for Renovate to run (or manually trigger via Renovate dashboard)
- [ ] Verify existing individual Renovate PRs get replaced with grouped PRs
- [ ] Verify any `actions/*` update PRs auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Groups Renovate updates into fewer PRs and enables automerge for specific updates in `renovate.json`.
> 
>   - **Behavior**:
>     - Replaces `config:recommended` with `packageRules` in `renovate.json` to group all dependency updates into a single PR.
>     - Adds automerge for `actions/*` GitHub Actions updates, including major version bumps.
>     - Adds automerge for pre-commit hook minor and patch updates.
>   - **Expected Result**:
>     - At most 3 PRs from Renovate: `github-actions` (auto-merged), `pre-commit hooks` (auto-merged for minor/patch), and `all dependencies` (grouped for manual review).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fkubernetes-monitoring&utm_source=github&utm_medium=referral)<sup> for 4fe9bc218b9b88386863ba1b3cf6392930e63116. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->