### PR TITLE
fix(bifrost): drop ANTHROPIC_API_KEY from DopplerSecret

### DIFF
--- a/k8s/monitoring/bifrost/configmap.yaml
+++ b/k8s/monitoring/bifrost/configmap.yaml
@@ -19,16 +19,6 @@ data:
             }
           ]
         },
-        "anthropic": {
-          "keys": [
-            {
-              "name": "anthropic-primary",
-              "value": "env.ANTHROPIC_API_KEY",
-              "models": [],
-              "weight": 1.0
-            }
-          ]
-        },
         "gemini": {
           "keys": [
             {

--- a/k8s/monitoring/bifrost/doppler-secret.yaml
+++ b/k8s/monitoring/bifrost/doppler-secret.yaml
@@ -10,9 +10,11 @@ spec:
     name: bifrost-provider-keys
     namespace: monitoring
     type: Opaque
+  # ANTHROPIC_API_KEY intentionally omitted — Claude Code talks to Anthropic
+  # directly via its own subscription. Bifrost only routes the non-Anthropic
+  # providers (OpenAI, Gemini, OpenRouter) plus local MLX.
   secrets:
     - OPENAI_API_KEY
-    - ANTHROPIC_API_KEY
     - GEMINI_API_KEY
     - OPENROUTER_API_KEY
   resyncSeconds: 60

--- a/k8s/monitoring/bifrost/statefulset.yaml
+++ b/k8s/monitoring/bifrost/statefulset.yaml
@@ -60,12 +60,6 @@ spec:
                   name: bifrost-provider-keys
                   key: OPENAI_API_KEY
                   optional: true
-            - name: ANTHROPIC_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: bifrost-provider-keys
-                  key: ANTHROPIC_API_KEY
-                  optional: true
             - name: GEMINI_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450 — PAL MCP → Bifrost migration

## Why

Claude Code talks to Anthropic directly via its own subscription. There's no reason to pay the PAL→Bifrost round-trip cost to reach Anthropic when the native client is already there. Bifrost's value is routing the *non-Anthropic* providers (OpenAI, Gemini, OpenRouter) plus local MLX.

The Doppler config `ai-ci-automation/prd` intentionally does not contain `ANTHROPIC_API_KEY` — listing it in the DopplerSecret spec caused incomplete syncs and would have forced adding an expensive key we don't want.

## What

Dropped `ANTHROPIC_API_KEY` from `k8s/monitoring/bifrost/doppler-secret.yaml` and added a comment explaining the intentional omission.

## Verification

Applied live to orbstack cluster:

```
$ kubectl -n monitoring get secret bifrost-provider-keys -o jsonpath='{.data}' | jq 'keys'
[
  "DOPPLER_CONFIG",
  "DOPPLER_ENVIRONMENT",
  "DOPPLER_PROJECT",
  "GEMINI_API_KEY",
  "OPENAI_API_KEY",
  "OPENROUTER_API_KEY"
]

$ curl -sf http://localhost:30080/v1/models | jq '.data | length'
509
```

Bifrost now serves 509 models across Gemini 2.x/3.x, OpenAI, OpenRouter, and local MLX after a rollout restart — confirming Phase C (Doppler K8s Operator bootstrap) of the Bifrost activation is complete.

## Test plan

- [x] Pre-commit hooks pass locally (kustomize build, kubeconform, yamllint, cspell, etc.)
- [x] Live cluster verification — secret sync, bifrost rollout, /v1/models count
- [ ] CI validate.yml passes
- [ ] CI e2e-tests.yml passes (deploy + smoke + pipeline)