### PR TITLE
fix(bifrost): raise mlx-local upstream timeout to 300s

### DIFF
--- a/k8s/monitoring/bifrost/configmap.yaml
+++ b/k8s/monitoring/bifrost/configmap.yaml
@@ -49,7 +49,8 @@ data:
             }
           ],
           "network_config": {
-            "base_url": "http://host.docker.internal:11434"
+            "base_url": "http://host.docker.internal:11434",
+            "default_request_timeout_in_seconds": 300
           },
           "custom_provider_config": {
             "base_provider_type": "openai",


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450 — Bifrost AI gateway migration umbrella

## Summary

Bifrost's default upstream request timeout (`network_config.default_request_timeout_in_seconds`) is 30 seconds. That's fine for idle Apple Silicon MLX — we measured <300 ms Bifrost overhead on top of ~12 s generation in the earlier session. But under concurrent load it's unusably short.

## Why

During a live benchmark session that tested Bifrost on top of an existing concurrent lm-eval workload (`math-hard`, 4-way concurrent against Qwen3-Coder-30B), every MLX request through Bifrost timed out at exactly 30.0 s with HTTP 504, while direct calls to vllm-mlx succeeded in 35–85 s.

**Root cause:** vllm-mlx serializes incoming requests behind its continuous-batching scheduler, and under a concurrent 4-way lm-eval load a trivial prompt can take 40–85 s end-to-end on Apple Silicon. The default 30 s Bifrost timeout fires before vllm-mlx can respond.

## Fix

Raise the upstream timeout for the `mlx-local` provider to 300 s. Matches realistic cold-load and under-load scenarios on Apple Silicon MLX without changing defaults for the cloud providers (OpenAI/Gemini/OpenRouter), which keep Bifrost's out-of-the-box 30 s timeout.

```diff
"network_config": {
-  "base_url": "http://host.docker.internal:11434"
+  "base_url": "http://host.docker.internal:11434",
+  "default_request_timeout_in_seconds": 300
},
```

## Verification (applied live during the session)

- **Bench A retry (post-patch):** Qwen3-Coder-30B one-word reply in 56.7 s wall clock (vs 30.0 s timeout pre-patch). Response body correct.
- **Bench D:** 5 parallel requests through Bifrost on top of 4-way concurrent lm-eval → 9 concurrent vllm-mlx streams → all 5 bench responses returned in 74.0 s total (not 5 × 74 s). Bifrost added zero serialization overhead at the gateway.
- **Bench B:** 3 sequential samples through Bifrost had ~0.74 s median overhead vs direct vllm-mlx calls — within jitter.

Full session narrative with all 10 benchmark results + 5 actionable findings is in the companion PR against `JacobPEvans/nix-ai`: `docs/session-reports/2026-04-10-bifrost-benchmark-session.md`.

## Known issue: E2E failure is unrelated to this PR

The `Deploy and run E2E tests` job failed on `tests/test_forwarding.py::TestGeminiLogPipeline::test_sentinel_file_visible_in_edge_pod` (69 of 70 tests passed). The failing test asserts that a sentinel file is readable inside the `cribl-edge-standalone` pod at `/home/gemini/.gemini/antigravity/brain/sentinel-PIPELINE_TEST_*.md` via a hostPath volume mount.

**This PR changes exactly one line** in `k8s/monitoring/bifrost/configmap.yaml`. Zero relation to `TestGeminiLogPipeline`, Gemini antigravity sentinel files, hostPath volume mounts, or `cribl-edge-standalone` pod config. Most likely a pre-existing flake or environment drift on the runner host. Failed job has been re-run via `gh run rerun --failed`. PR #140 also merged successfully earlier today despite the same runner showing as offline — the E2E check is not a hard admin-merge blocker.

If the rerun fails again on the same test, this should be tracked as a separate issue in the test suite and should not block this PR.

## Test plan

- [x] `kubectl apply` + rollout restart succeeded mid-session, new timeout took effect immediately
- [x] Pre-commit hooks pass locally (kustomize + kubeconform + yamllint + json validation)
- [x] All non-E2E CI green (validate, pre-commit, unit-tests, Dockerfile scan, test-deps, CodeQL)
- [ ] CI E2E passes on rerun OR is waived as unrelated pre-existing flake
