### PR TITLE
feat(bifrost): populate mlx-local static model list

### DIFF
--- a/k8s/monitoring/bifrost/configmap.yaml
+++ b/k8s/monitoring/bifrost/configmap.yaml
@@ -44,7 +44,29 @@ data:
             {
               "name": "mlx-key",
               "value": "not-needed",
-              "models": [],
+              "models": [
+                "mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
+                "mlx-community/DeepSeek-R1-Distill-Llama-70B-4bit",
+                "mlx-community/Devstral-2-123B-Instruct-2512-4bit",
+                "mlx-community/Devstral-Small-2-24B-Instruct-2512-4bit",
+                "mlx-community/GLM-4.5-Air-4bit",
+                "mlx-community/GLM-4.7-Flash-Claude-Opus-4.5-High-Reasoning-Distill-8bit",
+                "mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit",
+                "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit",
+                "mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit",
+                "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit",
+                "mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit",
+                "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit",
+                "mlx-community/Qwen3.5-122B-A10B-4bit",
+                "mlx-community/Qwen3.5-27B-4bit",
+                "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit",
+                "mlx-community/Qwen3.5-35B-A3B-4bit",
+                "mlx-community/Qwen3.5-9B-MLX-4bit",
+                "mlx-community/Seed-OSS-36B-Instruct-4bit",
+                "mlx-community/gemma-4-31b-it-4bit",
+                "mlx-community/gemma-4-e4b-it-4bit",
+                "mlx-community/gpt-oss-120b-4bit"
+              ],
               "weight": 1.0
             }
           ],


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450, JacobPEvans/nix-ai#469

## Summary

Populate the \`mlx-local\` provider's \`keys[0].models\` array in \`k8s/monitoring/bifrost/configmap.yaml\` with the 21 MLX models currently registered in \`~/.config/mlx/llama-swap.json\` so they show up in Bifrost's \`GET /v1/models\` response.

## Why

Bifrost's \`mlx-local\` custom provider **does not support dynamic model enumeration** (\`list_models\` is not implemented for the custom OpenAI-compatible provider adapter). As a result, the 21 MLX models in the local llama-swap catalog were previously invisible in \`GET /v1/models\`. Routing still worked when clients specified explicit \`mlx-local/<model-id>\` prefixes, but discoverability was incomplete — any SDK that queried \`/v1/models\` for available models saw zero MLX entries.

Bifrost logged the exact failure mode during the benchmark session:

\`\`\`text
failed to list models for provider mlx-local: list_models is not supported by
mlx-local provider: falling back onto the static datasheet
\`\`\`

The \"static datasheet\" is the \`models\` array in the provider's \`keys\` block — previously empty.

## Changes

Populated \`mlx-local.keys[0].models\` with the 21 entries from \`groups.mlx-models.members\` in llama-swap.json:

- DeepSeek-R1 variants (Qwen3-8B, Distill-Llama-70B)
- Devstral series (2-123B, Small-2-24B)
- GLM-4.5-Air, GLM-4.7-Flash-Claude-Opus-Distill
- Llama-4-Scout-17B-16E-Instruct
- Qwen3-Coder-30B (4bit + 8bit)
- Qwen3-Next-80B (Instruct 4bit/8bit + Thinking 4bit)
- Qwen3.5-9B, Qwen3.5-27B (+ Claude-Opus-Distilled), Qwen3.5-35B-A3B, Qwen3.5-122B-A10B
- Seed-OSS-36B
- gemma-4 series (31b, e4b)
- gpt-oss-120b

This is a **manual sync** for now. Automation (generating the list from llama-swap.json at deploy time) is a future follow-up if the list churns frequently.

## Test plan

- [x] Pre-commit hooks pass locally (kustomize build, kubeconform, yamllint, cspell, JSON validation)
- [ ] CI passes
- [ ] Post-merge live verification: \`curl -sf http://localhost:30080/v1/models | jq '[.data[] | .id] | map(select(startswith(\"mlx-local/\"))) | length'\` should return 21