### PR TITLE
fix(bifrost): raise probe timeoutSeconds 1→5 for defense in depth

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,6 +31,7 @@
     "dorny",
     "elif",
     "exfiltration",
+    "fasthttp",
     "fileconsumer",
     "gemini",
     "gitignored",

--- a/k8s/monitoring/bifrost/statefulset.yaml
+++ b/k8s/monitoring/bifrost/statefulset.yaml
@@ -89,6 +89,11 @@ spec:
             limits:
               memory: "512Mi"
               ephemeral-storage: "1Gi"
+          # Probe timeoutSeconds: 5 (vs default 1) is defense-in-depth
+          # against a saturated fasthttp worker pool potentially blocking
+          # /health responses under extreme concurrent load. See PR #143
+          # review thread for rationale. /health itself is a lightweight
+          # DB-ping check and normally returns in ~10ms.
           startupProbe:
             httpGet:
               path: /health
@@ -96,6 +101,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 12
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health
@@ -103,6 +109,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 30
             failureThreshold: 3
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
@@ -110,6 +117,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 5
+            timeoutSeconds: 5
       volumes:
         - name: config-ro
           configMap:

--- a/k8s/monitoring/bifrost/statefulset.yaml
+++ b/k8s/monitoring/bifrost/statefulset.yaml
@@ -89,11 +89,11 @@ spec:
             limits:
               memory: "512Mi"
               ephemeral-storage: "1Gi"
-          # Probe timeoutSeconds: 5 (vs default 1) is defense-in-depth
-          # against a saturated fasthttp worker pool potentially blocking
-          # /health responses under extreme concurrent load. See PR #143
-          # review thread for rationale. /health itself is a lightweight
-          # DB-ping check and normally returns in ~10ms.
+          # Probe timeoutSeconds bumped from default 1 to give /health
+          # headroom under extreme concurrent load. /health itself is a
+          # lightweight DB-ping check that normally returns in ~10 ms.
+          # startupProbe uses timeoutSeconds=4 (strictly less than the
+          # 5 s periodSeconds) to prevent overlapping probe execution.
           startupProbe:
             httpGet:
               path: /health
@@ -101,7 +101,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 12
-            timeoutSeconds: 5
+            timeoutSeconds: 4
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450, JacobPEvans/orbstack-kubernetes#143

## Summary

Bump \`timeoutSeconds\` from the Kubernetes default (1s) to 5s on all three Bifrost pod probes (\`startupProbe\`, \`livenessProbe\`, \`readinessProbe\`) in \`k8s/monitoring/bifrost/statefulset.yaml\`. Defense-in-depth only; no functional change in normal operation.

## Why

Follow-up from the gemini-code-assist review thread on #143, which raised a defense-in-depth concern that the new 300s \`mlx-local\` upstream timeout could interact badly with 1s probe timeouts under sustained concurrent load.

I pushed back in the review that the original concern doesn't technically apply:

- Probes target \`/health\` on port 8080, not \`/v1/chat/completions\`
- Bifrost's \`/health\` endpoint is a lightweight DB ping (\`{\"components\": {\"db_pings\": \"ok\"}, \"status\": \"ok\"}\`) that returns in ~10ms
- fasthttp's async I/O model doesn't block \`/health\` workers while upstream requests are in flight
- Verified during the benchmark session: \`/health\` responded in <100ms even while Bifrost was handling 9 concurrent streams against MLX

**Still**, bumping \`timeoutSeconds: 1 → 5\` is cheap, covers hypothetical future bugs where \`/health\` does somehow get starved, and has zero downside in normal operation. The probes still fire at the same cadence (\`periodSeconds\` unchanged), still fail after the same number of consecutive failures (\`failureThreshold\` unchanged) — we just give each probe call a larger response window.

## Changes

- Add \`timeoutSeconds: 5\` to \`startupProbe\`, \`livenessProbe\`, \`readinessProbe\` in \`statefulset.yaml\`
- Add an explanatory comment block above the probes citing the rationale
- Add \`fasthttp\` to \`.cspell.json\` since it now appears in the statefulset comment

## Test plan

- [x] Pre-commit hooks pass locally (kustomize + kubeconform + yamllint + cspell)
- [ ] CI passes
- [ ] Post-merge: Bifrost pod rolls cleanly, \`/health\` probe checks still fire every \`periodSeconds\`, no regression in pod readiness behavior