### PR TITLE
fix(bifrost): use clean multiples of 10 for all probe timings

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,7 +67,7 @@ make deploy-doppler
 
 ## Cribl Stream
 
-- **cribl-stream-standalone**: Local leader with UI at <http://localhost:30900> (admin / `CRIBL_STREAM_PASSWORD`)
+- **cribl-stream-standalone**: Local leader with UI at `http://localhost:30900` (admin / `CRIBL_STREAM_PASSWORD`)
 
 ## OTLP Telemetry
 

--- a/k8s/monitoring/bifrost/statefulset.yaml
+++ b/k8s/monitoring/bifrost/statefulset.yaml
@@ -91,33 +91,34 @@ spec:
               ephemeral-storage: "1Gi"
           # Health-probe timings. All probes hit /health, which is a
           # lightweight DB-ping check that normally returns in ~10 ms.
-          # periodSeconds / initialDelaySeconds are multiples of 10 for
-          # readability; timeoutSeconds gives ~10× headroom over the
-          # expected response time under concurrent load; failureThreshold
-          # is expressed as a retry count rather than a raw time budget.
+          # Timing fields are multiples of 10 for readability;
+          # timeoutSeconds provides generous headroom for transient
+          # latency under concurrent load; failureThreshold is expressed
+          # as a retry count rather than a raw time budget.
+          # livenessProbe and readinessProbe omit initialDelaySeconds
+          # because Kubernetes does not start them until the startupProbe
+          # has succeeded — any initial delay there would be dead time.
           startupProbe:
             httpGet:
               path: /health
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 20
-            failureThreshold: 6        # ~2 min startup budget (6 × 20 s)
+            failureThreshold: 6        # allow up to 6 failed startup checks
             timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3        # ~90 s tolerance
+            failureThreshold: 3        # 3 consecutive failures before restart
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 10
             periodSeconds: 20
-            failureThreshold: 3        # ~60 s tolerance
+            failureThreshold: 3        # 3 consecutive failures before unready
             timeoutSeconds: 10
       volumes:
         - name: config-ro

--- a/k8s/monitoring/bifrost/statefulset.yaml
+++ b/k8s/monitoring/bifrost/statefulset.yaml
@@ -89,35 +89,36 @@ spec:
             limits:
               memory: "512Mi"
               ephemeral-storage: "1Gi"
-          # Probe timeoutSeconds bumped from default 1 to give /health
-          # headroom under extreme concurrent load. /health itself is a
+          # Health-probe timings. All probes hit /health, which is a
           # lightweight DB-ping check that normally returns in ~10 ms.
-          # startupProbe uses timeoutSeconds=4 (strictly less than the
-          # 5 s periodSeconds) to prevent overlapping probe execution.
+          # periodSeconds / initialDelaySeconds are multiples of 10 for
+          # readability; timeoutSeconds gives ~10× headroom over the
+          # expected response time under concurrent load; failureThreshold
+          # is expressed as a retry count rather than a raw time budget.
           startupProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 12
-            timeoutSeconds: 4
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 6        # ~2 min startup budget (6 × 20 s)
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 15
+            initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
-            timeoutSeconds: 5
+            failureThreshold: 3        # ~90 s tolerance
+            timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /health
               port: 8080
             initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 5
-            timeoutSeconds: 5
+            periodSeconds: 20
+            failureThreshold: 3        # ~60 s tolerance
+            timeoutSeconds: 10
       volumes:
         - name: config-ro
           configMap:


### PR DESCRIPTION
Refs JacobPEvans/nix-ai#450

## Summary

Follow-up to #147 (merged). Reworks all three Bifrost health probes to use clean, round timing values instead of the arbitrary 4/5 second picks that landed in the previous PR. Applies the clean-numbers principle consistently across \`startupProbe\`, \`livenessProbe\`, and \`readinessProbe\` rather than just the one probe I was initially trying to fix for the overlap bug.

## Why

The PR #147 fix for the \`startupProbe\` overlap introduced \`timeoutSeconds: 4\` because it needed to be strictly less than the existing \`periodSeconds: 5\`. That picked an arbitrary number to satisfy a constraint rather than picking clean round values and re-shaping the probe cadence around them. \`livenessProbe\` and \`readinessProbe\` also had \`timeoutSeconds: 5\` without clearly meaningful ratios. This PR cleans it up consistently.

## Changes

| Probe | Field | Before | After | Note |
|---|---|---|---|---|
| startupProbe | initialDelaySeconds | 5 | **10** | |
| startupProbe | periodSeconds | 5 | **20** | |
| startupProbe | failureThreshold | 12 | **6** | 6 × 20 s = ~2 min startup budget |
| startupProbe | timeoutSeconds | 4 | **10** | now strictly < 20 s period |
| livenessProbe | initialDelaySeconds | 15 | **30** | |
| livenessProbe | periodSeconds | 30 | 30 | already clean |
| livenessProbe | failureThreshold | 3 | 3 | already a meaningful retry count |
| livenessProbe | timeoutSeconds | 5 | **10** | |
| readinessProbe | initialDelaySeconds | 10 | 10 | already clean |
| readinessProbe | periodSeconds | 10 | **20** | so 10 s timeout is strictly less |
| readinessProbe | failureThreshold | 5 | **3** | 3 × 20 s = ~60 s tolerance |
| readinessProbe | timeoutSeconds | 5 | **10** | |

**All timing values are now multiples of 10 seconds.** \`failureThreshold\` is expressed as a small retry count (3 or 6) rather than a raw time budget — semantically meaningful at a glance.

## Design principle (new comment block)

Rewrote the comment above the probes to state the rule rather than the history of this particular PR:

\`\`\`yaml
# Health-probe timings. All probes hit /health, which is a
# lightweight DB-ping check that normally returns in ~10 ms.
# periodSeconds / initialDelaySeconds are multiples of 10 for
# readability; timeoutSeconds gives ~10× headroom over the
# expected response time under concurrent load; failureThreshold
# is expressed as a retry count rather than a raw time budget.
\`\`\`

## Budgets

Total budgets land close to (or generously above) the original intent:

- **Startup**: ~130 s (was ~65 s) — still well under any reasonable cold-start ceiling
- **Liveness**: ~120 s tolerance (was ~105 s)
- **Readiness**: ~70 s tolerance (was ~60 s)

\`timeoutSeconds\` (10 s) is strictly less than \`periodSeconds\` on every probe (20 or 30), so **no overlapping probe execution under any circumstance** — fixes the overlap pattern my previous PR only solved for \`startupProbe\`.

## Test plan

- [x] Pre-commit hooks pass locally (kustomize build, kubeconform, yamllint)
- [ ] CI passes
- [ ] Post-merge live: Bifrost pod rolls cleanly with new probe timings, \`kubectl describe pod\` shows the new values