### PR TITLE
fix(bifrost): enable list_models for mlx-local provider

### DIFF
--- a/k8s/monitoring/bifrost/configmap.yaml
+++ b/k8s/monitoring/bifrost/configmap.yaml
@@ -55,6 +55,7 @@ data:
           "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
+              "list_models": true,
               "chat_completion": true,
               "chat_completion_stream": true
             }


### PR DESCRIPTION
# PR #176: Enable list_models for mlx-local provider

## Summary

- Add `list_models: true` to `mlx-local`'s `allowed_requests` in the Bifrost configmap
- Bifrost now proxies `GET /v1/models` to `host.docker.internal:11434` at startup
- Populates model catalog with all 21 local MLX models (was empty before)
- Models appear as `mlx-local/mlx-community/<name>`

## Root Cause

The `mlx-local` custom provider config only enabled `chat_completion` and
`chat_completion_stream`. Without `list_models`, Bifrost never queried the MLX
server's `/v1/models` endpoint, leaving the catalog empty.

## Verification

Deployed and verified on OrbStack cluster:

```bash
curl localhost:30080/v1/models | \
  jq '[.data[].id | select(startswith("mlx"))]'
# Returns all 21 mlx-community models (was [] before fix)

curl localhost:30080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-local/mlx-community/Qwen3.5-27B-4bit",
    "messages": [{"role":"user","content":"hi"}],
    "max_tokens": 5
  }'
# Returns successful response
```

**Routing format note:** Bifrost requires `provider/model` format for all
requests, including cloud models (`openai/gpt-4o`, `gemini/gemini-2.0-flash`).
MLX models use `mlx-local/mlx-community/<name>` format. Bare `mlx-community/<name>`
routing is not supported by Bifrost's architecture. PAL MCP routing config
update tracked in JacobPEvans/nix-ai#557.

## Test Plan

- [x] Deployed with `make deploy` on OrbStack cluster
- [x] `curl localhost:30080/v1/models` returns 21 MLX models (was 0)
- [x] `mlx-local/mlx-community/Qwen3.5-27B-4bit` routes successfully
- [ ] CI validate passes (ubuntu-latest)
- [ ] E2E tests pass (self-hosted macOS)

Closes #175
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
