### PR TITLE
fix(deps): bump requests minimum to >=2.33.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ opentelemetry-exporter-otlp-proto-grpc>=1.20.0
 opentelemetry-exporter-otlp-proto-http>=1.20.0
 pytest>=8.0.0
 pyyaml>=6.0
-requests>=2.28.0
+requests>=2.33.0


### PR DESCRIPTION
## Summary

- Bump `requests` version floor from `>=2.28.0` to `>=2.33.0` in test dependencies

## Motivation

The previous floor (`>=2.28.0`) allowed installing versions affected by three moderate-severity vulnerabilities:

| GHSA | Description | Fixed In |
|---|---|---|
| GHSA-gc5v-m9x4-r6x2 | Insecure temp file reuse | 2.33.0 |
| GHSA-9hjg-9r4m-mvj7 | .netrc credentials leak | 2.32.4 |
| GHSA-9wx4-h78v-vm56 | Session verify=False issue | 2.32.0 |

## Test plan

- [ ] `pip install -r tests/requirements.txt` resolves successfully
- [ ] Existing tests pass with requests >=2.33.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)