### PR TITLE
fix(bifrost): add $schema field to silence config warning

### DIFF
--- a/k8s/monitoring/bifrost/configmap.yaml
+++ b/k8s/monitoring/bifrost/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
 data:
   config.json: |
     {
+      "$schema": "https://www.getbifrost.ai/schema",
       "providers": {
         "openai": {
           "keys": [


### PR DESCRIPTION
# Bifrost Schema Configuration

## Summary

Bifrost logs a startup warning when the `$schema` field is absent from its configuration.
This fix adds the schema declaration as the first field in the Bifrost ConfigMap to silence
the warning on every pod start.

## Changes

- Added `"$schema": "https://www.getbifrost.ai/schema"` as the first field in
  `k8s/monitoring/bifrost/configmap.yaml`'s `config.json` block

## Test Plan

- [ ] Apply the updated configmap: `kubectl apply -f k8s/monitoring/bifrost/configmap.yaml`
- [ ] Roll the Bifrost deployment: `kubectl rollout restart deployment/bifrost -n monitoring`
- [ ] Verify logs: `kubectl logs -n monitoring deploy/bifrost | head -20` — confirm schema
  warning is gone
