### PR TITLE
docs: add CI and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # orbstack-kubernetes
 
+[![validate](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/validate.yml/badge.svg)](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/validate.yml) [![e2e-tests](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/e2e-tests.yml) [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 Kubernetes monitoring stack for local OrbStack cluster. Collects, processes, and routes logs from Claude Code, Ollama, terminal sessions, and ephemeral AI containers.
 
 ## Components


### PR DESCRIPTION
# Summary

Add CI status and license badges to README header for improved project visibility.

- Added GitHub Actions CI status badges (`validate.yml`, `e2e-tests.yml`) to README
- Added Apache-2.0 license badge to README

## Changes

- **README.md**: Added badge row to header section
  - GitHub Actions: Validate workflow status
  - GitHub Actions: E2E tests workflow status
  - License: Apache-2.0 badge

## Test Plan

- [x] README renders correctly with badges
- [x] Badges link to correct GitHub Actions workflows and license file
- [x] Badge markdown syntax is valid
