### PR TITLE
docs: add SECURITY.md, CONTRIBUTING.md, CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JacobPEvans

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,24 @@ This is a single-maintainer repository for a local OrbStack Kubernetes cluster. 
 
 ## Setup
 
+Requires: kubectl, kustomize, kubeconform, OrbStack with k3s running.
+
+**With direnv (recommended)** — auto-activates the dev shell whenever you `cd` into the worktree:
+
 ```sh
-direnv allow      # one-time per worktree, auto-activates on cd
-nix develop       # manual activation if direnv isn't installed
+direnv allow      # one-time per worktree
 ```
 
-Requires: kubectl, kustomize, kubeconform, OrbStack with k3s running.
+**Without direnv** — manually enter the dev shell each time:
+
+```sh
+nix develop
+```
 
 ## Workflow
 
 1. Sync and create a worktree before starting:
+
    ```sh
    cd ~/git/orbstack-kubernetes/main
    git fetch --prune origin && git pull
@@ -21,11 +29,13 @@ Requires: kubectl, kustomize, kubeconform, OrbStack with k3s running.
    ```
 
 2. Make changes, then run unit tests (no cluster required):
+
    ```sh
    make test-unit
    ```
 
 3. Verify the full stack if your change touches `k8s/` or `scripts/`:
+
    ```sh
    make deploy
    make test-e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+This is a single-maintainer repository for a local OrbStack Kubernetes cluster. External contributions are welcome but the bar is high — changes must not break the live monitoring pipeline.
+
+## Setup
+
+```sh
+direnv allow      # one-time per worktree, auto-activates on cd
+nix develop       # manual activation if direnv isn't installed
+```
+
+Requires: kubectl, kustomize, kubeconform, OrbStack with k3s running.
+
+## Workflow
+
+1. Sync and create a worktree before starting:
+   ```sh
+   cd ~/git/orbstack-kubernetes/main
+   git fetch --prune origin && git pull
+   git worktree add ~/git/orbstack-kubernetes/<type>/<name> -b <type>/<name> main
+   ```
+
+2. Make changes, then run unit tests (no cluster required):
+   ```sh
+   make test-unit
+   ```
+
+3. Verify the full stack if your change touches `k8s/` or `scripts/`:
+   ```sh
+   make deploy
+   make test-e2e
+   ```
+
+4. Open a PR with a [Conventional Commit](https://www.conventionalcommits.org/) title:
+   - `fix:` for bug fixes and small adjustments → patch release
+   - `feat:` for new capabilities → minor release
+   - `chore:`, `docs:`, `ci:` for non-release changes
+
+## Rules
+
+- **No plaintext secrets.** All secrets live in `secrets.enc.yaml` (SOPS-encrypted). See `docs/DEPLOYMENT.md`.
+- **No hardcoded local paths.** Base manifests use `PLACEHOLDER_HOME_DIR`; real paths are injected by the generated overlay.
+- **Edge → Stream → Splunk** is the only allowed data path. The architecture invariant tests enforce this.
+- **Image tags stay `latest`** for upstream images. Renovate and the Trivy scan handle supply-chain hygiene.
+
+## Testing
+
+See [docs/TESTING.md](docs/TESTING.md) for the full test tier breakdown (unit → smoke → pipeline → forwarding → sourcetypes).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+Use [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) for this repository. Do not open a public issue for security vulnerabilities.
+
+## Scope
+
+This repository manages Kubernetes manifests and tooling for a local OrbStack development cluster. It does not handle production customer data. The primary security concerns are:
+
+- **Supply-chain integrity** of container images (Cribl, OTEL Collector, Bifrost, etc.)
+- **Secret hygiene** — all secrets are managed via SOPS + Doppler, never committed in plaintext
+- **GitHub Actions security** — workflows are linted by Zizmor, untrusted external actions are SHA-pinned
+
+## Dependency Updates
+
+Renovate manages dependency updates with a 3-day stabilization delay. Trusted external GitHub Actions use version tags; untrusted actions use SHA pins. See the org-level [SECURITY.md](https://github.com/JacobPEvans/.github/blob/main/SECURITY.md) for the full dependency trust tier model.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ This repository manages Kubernetes manifests and tooling for a local OrbStack de
 
 - **Supply-chain integrity** of container images (Cribl, OTEL Collector, Bifrost, etc.)
 - **Secret hygiene** — all secrets are managed via SOPS + Doppler, never committed in plaintext
-- **GitHub Actions security** — workflows are linted by Zizmor, untrusted external actions are SHA-pinned
+- **GitHub Actions security** — untrusted external actions are SHA-pinned; CodeQL analysis (Python + Actions) is a required status check enforced by repository ruleset
 
 ## Dependency Updates
 


### PR DESCRIPTION
## Summary

- **`SECURITY.md`**: repo-scoped policy pointing to GitHub private vulnerability reporting. Scoped to the local OrbStack cluster threat model (supply chain, secret hygiene, Actions security). Links to org `SECURITY.md` for the full dependency trust tier model rather than duplicating it.
- **`CONTRIBUTING.md`**: covers worktree/direnv setup flow, `make test-unit`/`make deploy`/`make test-e2e` targets, Conventional Commit title conventions (aligned with release-please), and the key architecture rules (placeholder paths, Edge→Stream→Splunk invariant, image tag policy).
- **`CODEOWNERS`**: single-maintainer, `* @JacobPEvans`.
- **Review feedback (41efcbb)**:
  - `SECURITY.md`: replaced inaccurate zizmor claim with actual enforcement (SHA-pinning + CodeQL required checks). Zizmor is not wired up in this repo.
  - `CONTRIBUTING.md`: split Setup into 'With direnv (recommended)' and 'Without direnv' so the two flows read as mutually exclusive. Fixed markdownlint MD031 (blank lines around fenced code blocks inside list items).

## Test plan

- [x] `markdownlint-cli2` passes on new files
- [x] CI gate passes (no lint failures on new markdown files)
- [ ] After merge: GitHub shows "Security policy" and "Contributing" tabs populated