### PR TITLE
🤖 Fix #194: add email+IPv4 PII masking to Cribl Stream pipeline

### DIFF
--- a/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml
+++ b/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml
@@ -75,6 +75,15 @@ data:
                 : (datatype||'claude-code-unknown').replace('claude-code-','claude:code:')
             - name: source
               value: "source || 'cribl-stream'"
+      - id: mask
+        filter: "true"
+        disabled: false
+        conf:
+          rules:
+            - regex: '/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g'
+              replacement: '*'
+            - regex: '/\b(?:\d{1,3}\.){3}\d{1,3}\b/g'
+              replacement: '*'
   pipelines-route.yml: |
     id: default
     groups: {}

--- a/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml
+++ b/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml
@@ -79,10 +79,12 @@ data:
         filter: "true"
         disabled: false
         conf:
+          fields:
+            - '*'
           rules:
             - regex: '/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g'
               replacement: '*'
-            - regex: '/\b(?:\d{1,3}\.){3}\d{1,3}\b/g'
+            - regex: '/\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g'
               replacement: '*'
   pipelines-route.yml: |
     id: default

--- a/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml
+++ b/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml
@@ -79,8 +79,6 @@ data:
         filter: "true"
         disabled: false
         conf:
-          fields:
-            - '*'
           rules:
             - regex: '/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g'
               replacement: '*'


### PR DESCRIPTION
Closes #194

## Problem

`cribl-stream-standalone` configmap has no PII masking in its default pipeline. Email addresses and IPv4 addresses flow through unredacted into Splunk indexes. The `feature/centralized-log-masking` branch containing this fix was dropped during cleanup on 2026-04-24.

## Approach

Add a Cribl Stream `mask` pipeline function immediately after the existing `eval` block in `pipelines-force-splunk-meta.yml`. Two regex rules redact:
- Email addresses (`/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g`) → `*`
- IPv4 addresses (`/\b(?:\d{1,3}\.){3}\d{1,3}\b/g`) → `*`

The `eval` function (which sets `index`, `sourcetype`, `source`) runs first; the `mask` function runs after, so metadata enrichment is not affected.

## Files changed

- `k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml` — add `mask` pipeline function with email and IPv4 redaction rules after the `eval` block

## CI status

passed — Verify test dependencies ✅, validate ✅, pre-commit ✅, Unit tests ✅, Scan Dockerfiles ✅

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
