### PR TITLE
fix(tests): accept quoted url values in url_present_in_outputs_yaml

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -151,6 +151,12 @@ def send_trace_with_retry(
 def url_present_in_outputs_yaml(url: str, yaml_text: str) -> bool:
     """Return True if url appears as a 'url:' value in the YAML text.
 
-    Matches lines of the form:  url: <value>  (with optional surrounding whitespace).
+    Matches lines of the form:  url: <value>  with optional surrounding
+    whitespace and an optional matching pair of single or double quotes
+    around the value. The Cribl Stream configmap template wraps the URL
+    in double quotes
+    (k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml),
+    so the deployed outputs.yml renders as `url: "https://..."`; strict
+    unquoted matching gives a false negative.
     """
-    return bool(re.search(rf"^\s*url:\s*{re.escape(url)}\s*$", yaml_text, re.MULTILINE))
+    return bool(re.search(rf"""^\s*url:\s*(['"]?){re.escape(url)}\1\s*$""", yaml_text, re.MULTILINE))


### PR DESCRIPTION
## Summary

The configmap template for Cribl Stream wraps the HEC URL in **double quotes** ([\`k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml:12\`](https://github.com/JacobPEvans/orbstack-kubernetes/blob/main/k8s/monitoring/cribl-stream-standalone/configmap-cribl-config.yaml#L12)), so after \`sed\` substitution the deployed \`outputs.yml\` renders as:

\`\`\`yaml
url: "https://10.0.1.200:8088/services/collector"
\`\`\`

But the test helper's regex (\`tests/helpers.py:151\`) required strictly **unquoted** values:

\`\`\`python
re.search(rf"^\s*url:\s*{re.escape(url)}\s*$", yaml_text, re.MULTILINE)
\`\`\`

Result: false negative on every run. \`test_splunk_hec_url_matches_secret\` has failed continuously since this template/test pair was introduced, blocking the E2E gate on PRs #234 and #237.

## Fix

Allow an optional matching pair of single or double quotes around the URL value:

\`\`\`python
re.search(rf"""^\s*url:\s*(['"]?){re.escape(url)}\1\s*$""", yaml_text, re.MULTILINE)
\`\`\`

The \`\1\` back-reference forces matching pairs only — \`url: "..."\` matches, \`url: '...'\` matches, \`url: ...\` matches, but \`url: "...\` (mismatched) does not.

## Test plan

- [x] Helper unit-tested against six representative cases:
  - double-quoted ✓ True (was False — this is the bug)
  - single-quoted ✓ True
  - unquoted ✓ True (preserves prior behavior)
  - mismatched-quote ✓ False
  - unsubstituted placeholder ✓ False
  - different URL ✓ False
- [x] \`pre-commit run --files tests/helpers.py\` — passes (ruff lint + format)
- [ ] CI: E2E \`test_splunk_hec_url_matches_secret\` should now pass

Assisted-by: Claude <noreply@anthropic.com>