### PR TITLE
fix(ci): also ignore historical kubernetes-monitoring self-refs

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,7 +4,8 @@
     { "pattern": "^http://127\\.0\\.0\\.1" },
     { "pattern": "^http://cribl" },
     { "pattern": "^http://otel" },
-    { "pattern": "github\\.com/JacobPEvans/orbstack-kubernetes(/|$)" }
+    { "pattern": "github\\.com/JacobPEvans/orbstack-kubernetes(/|$)" },
+    { "pattern": "github\\.com/JacobPEvans/kubernetes-monitoring(/|$)" }
   ],
   "retryOn429": true,
   "retryCount": 3,


### PR DESCRIPTION
## Summary

PR #242 repaired the typo so the link-checker correctly recognizes \`orbstack-kubernetes\` self-references. But that fix **removed** the implicit protection for CHANGELOG entries that still link to \`github.com/JacobPEvans/kubernetes-monitoring/...\` — the repo's name before the \`c21d9ca\` rename.

Those URLs return **404** today (GitHub doesn't redirect deleted repo names indefinitely). The first PR rebased onto post-#242 main (#240) failed pre-commit with 47 new \`Status: 404\` errors against those historical CHANGELOG links.

## Fix

Restore protection for the old name alongside the new one:

\`\`\`json
{ "pattern": "github\\.com/JacobPEvans/orbstack-kubernetes(/|$)" },
{ "pattern": "github\\.com/JacobPEvans/kubernetes-monitoring(/|$)" }
\`\`\`

CHANGELOG history is correctly preserved (don't rewrite history) and link validation still catches real broken references in current docs.

## Test plan

- [x] \`jq empty .markdown-link-check.json\` — valid
- [ ] CI: pre-commit's link checker should stop hitting the 47 historical 404s

Assisted-by: Claude <noreply@anthropic.com>