### PR TITLE
fix(makefile): invoke pytest via python -m to avoid baked shebang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@ NAMESPACE := monitoring
 GITHUB_REPO ?= JacobPEvans/orbstack-kubernetes
 KUSTOMIZE_DIRS := k8s/monitoring
 MONITORING_STATEFULSETS := otel-collector cribl-edge-managed cribl-edge-standalone cribl-stream-standalone cribl-mcp-server bifrost
-PYTEST_CHECK := test -x .venv/bin/python || { echo "Run 'make test-setup' first to install test dependencies"; exit 1; }
+
+# Virtual environment configuration
+VENV ?= .venv
+PYTHON ?= $(VENV)/bin/python
+PIP ?= $(VENV)/bin/pip
+SYSTEM_PYTHON ?= python3
+
+VENV_CHECK := test -x $(PYTHON) || { echo "Run 'make test-setup' first to install test dependencies"; exit 1; }
 UNIT_TEST_FILES := tests/test_unit.py tests/test_manifests.py tests/test_conftest_utils.py
 
 help: ## Show all targets
@@ -45,49 +52,49 @@ build-images: ## Build Claude Code and Gemini CLI Docker images
 
 
 test: ## Run all pipeline tests (requires deployed stack)
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest tests/ -v
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest tests/ -v
 
 test-smoke: ## Run smoke tests only (pod health + services)
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest tests/test_smoke.py -v
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest tests/test_smoke.py -v
 
 test-pipeline: ## Run OTLP pipeline tests (sends test traces)
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest tests/test_pipeline.py -v
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest tests/test_pipeline.py -v
 
 test-forwarding: ## Run forwarding tests (Cribl pipeline)
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest tests/test_forwarding.py -v
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest tests/test_forwarding.py -v
 
 test-sourcetypes: ## Run per-sourcetype E2E tests
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest tests/test_sourcetypes.py -v
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest tests/test_sourcetypes.py -v
 
 test-unit: ## Run unit tests (no cluster required)
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest $(UNIT_TEST_FILES) -v
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest $(UNIT_TEST_FILES) -v
 
 test-e2e: ## Run full test suite in order (smoke → pipeline → forwarding → sourcetypes)
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short -x
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short -x
 
 test-all: ## Run all tests in order: unit → smoke → pipeline → forwarding → sourcetypes
-	@$(PYTEST_CHECK)
-	.venv/bin/python -m pytest $(UNIT_TEST_FILES) tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short
+	@$(VENV_CHECK)
+	$(PYTHON) -m pytest $(UNIT_TEST_FILES) tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short
 
 test-setup: ## Install test dependencies in virtual environment
-	python3 -m venv .venv
-	.venv/bin/python -m pip install -r tests/requirements.txt
+	$(SYSTEM_PYTHON) -m venv $(VENV)
+	$(PYTHON) -m pip install -r tests/requirements.txt
 
 warmup-e2e: ## Verify full pipeline delivers traces to Splunk (blocking gate)
-	@$(PYTEST_CHECK)
-	.venv/bin/python3 scripts/warmup-e2e.py
+	@$(VENV_CHECK)
+	$(PYTHON) scripts/warmup-e2e.py
 
 warmup: ## Send warmup trace to prime OTEL gRPC connection (retries 3x)
-	@$(PYTEST_CHECK)
+	@$(VENV_CHECK)
 	@for attempt in 1 2 3; do \
-		if .venv/bin/python3 scripts/otel-warmup.py; then \
+		if $(PYTHON) scripts/otel-warmup.py; then \
 			echo "Warmup succeeded on attempt $$attempt"; \
 			break; \
 		elif [ "$$attempt" -lt 3 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ NAMESPACE := monitoring
 GITHUB_REPO ?= JacobPEvans/orbstack-kubernetes
 KUSTOMIZE_DIRS := k8s/monitoring
 MONITORING_STATEFULSETS := otel-collector cribl-edge-managed cribl-edge-standalone cribl-stream-standalone cribl-mcp-server bifrost
-PYTEST_CHECK := test -x .venv/bin/pytest || { echo "Run 'make test-setup' first to install test dependencies"; exit 1; }
+PYTEST_CHECK := test -x .venv/bin/python || { echo "Run 'make test-setup' first to install test dependencies"; exit 1; }
 UNIT_TEST_FILES := tests/test_unit.py tests/test_manifests.py tests/test_conftest_utils.py
 
 help: ## Show all targets
@@ -46,39 +46,39 @@ build-images: ## Build Claude Code and Gemini CLI Docker images
 
 test: ## Run all pipeline tests (requires deployed stack)
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest tests/ -v
+	.venv/bin/python -m pytest tests/ -v
 
 test-smoke: ## Run smoke tests only (pod health + services)
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest tests/test_smoke.py -v
+	.venv/bin/python -m pytest tests/test_smoke.py -v
 
 test-pipeline: ## Run OTLP pipeline tests (sends test traces)
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest tests/test_pipeline.py -v
+	.venv/bin/python -m pytest tests/test_pipeline.py -v
 
 test-forwarding: ## Run forwarding tests (Cribl pipeline)
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest tests/test_forwarding.py -v
+	.venv/bin/python -m pytest tests/test_forwarding.py -v
 
 test-sourcetypes: ## Run per-sourcetype E2E tests
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest tests/test_sourcetypes.py -v
+	.venv/bin/python -m pytest tests/test_sourcetypes.py -v
 
 test-unit: ## Run unit tests (no cluster required)
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest $(UNIT_TEST_FILES) -v
+	.venv/bin/python -m pytest $(UNIT_TEST_FILES) -v
 
 test-e2e: ## Run full test suite in order (smoke → pipeline → forwarding → sourcetypes)
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short -x
+	.venv/bin/python -m pytest tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short -x
 
 test-all: ## Run all tests in order: unit → smoke → pipeline → forwarding → sourcetypes
 	@$(PYTEST_CHECK)
-	.venv/bin/pytest $(UNIT_TEST_FILES) tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short
+	.venv/bin/python -m pytest $(UNIT_TEST_FILES) tests/test_smoke.py tests/test_pipeline.py tests/test_forwarding.py tests/test_sourcetypes.py -v --tb=short
 
 test-setup: ## Install test dependencies in virtual environment
 	python3 -m venv .venv
-	.venv/bin/pip install -r tests/requirements.txt
+	.venv/bin/python -m pip install -r tests/requirements.txt
 
 warmup-e2e: ## Verify full pipeline delivers traces to Splunk (blocking gate)
 	@$(PYTEST_CHECK)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ MONITORING_STATEFULSETS := otel-collector cribl-edge-managed cribl-edge-standalo
 # Virtual environment configuration
 VENV ?= .venv
 PYTHON ?= $(VENV)/bin/python
-PIP ?= $(VENV)/bin/pip
 SYSTEM_PYTHON ?= python3
 
 VENV_CHECK := test -x $(PYTHON) || { echo "Run 'make test-setup' first to install test dependencies"; exit 1; }


### PR DESCRIPTION
## Summary

The Python `venv` module bakes the absolute path of `.venv/bin/python3` into the shebang of every script in `.venv/bin/` at creation time. When the project moves on disk — as happened here after the workspace was reorganized from `~/git/orbstack-kubernetes/` to `~/git/public/orbstack-kubernetes/` — every `.venv/bin/pytest` invocation breaks with:

```
.venv/bin/pytest: bad interpreter: /Users/jevans/git/orbstack-kubernetes/main/.venv/bin/python3: no such file or directory
```

`make test-all` and friends silently fail until somebody runs `rm -rf .venv && make test-setup`. Local-only failure mode (CI checks out fresh each run), but disruptive when hit.

The `.venv/bin/python` entry itself is a symlink to the system Python — running it directly works regardless of where the venv lives. `python -m pytest` invokes pytest as a module via that python, bypassing the shebang.

## Changes

- Replace `.venv/bin/pytest` → `$(PYTHON) -m pytest` across all 8 test targets
- Replace `.venv/bin/pip` → `$(PYTHON) -m pip` in `test-setup`
- Replace `.venv/bin/python3 scripts/X.py` → `$(PYTHON) scripts/X.py` in warmup targets
- Switch venv-presence gate from `test -x .venv/bin/pytest` to `test -x .venv/bin/python`
- Factor `.venv` path into named vars (`VENV`, `PYTHON`, `SYSTEM_PYTHON`) and rename `PYTEST_CHECK` → `VENV_CHECK`

## Test Plan

- [x] `make test-setup` from a fresh worktree builds the venv
- [x] `make test-unit` — 99 unit tests pass via the new invocation (local, 0.34s)
- [x] `make test-all` against the OrbStack cluster — 215 / 216 tests passed in 11m24s
  - 1 skip is benign (`test_stats_sourcetype_exists`, documented in `docs/TESTING.md`)
  - 1 fail (`test_gemini_session_sourcetype`) is an upstream pack bug — Gemini CLI 0.43.0 now writes `.jsonl` instead of `.json`. Upstream fix: JacobPEvans/cc-edge-gemini-antigravity-io#10. Does not affect this Makefile change.
- [x] CI validate, unit tests, CodeQL, pre-commit, Dockerfile scan all pass
- [x] CI E2E (self-hosted runner) passes — gemini test skips on the runner because `gemini` CLI isn't in CI's PATH, so the upstream pack bug doesn't surface there

Assisted-by: Claude <noreply@anthropic.com>