### PR TITLE
docs: stop dictating filesystem layout in README/CONTRIBUTING/TESTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,15 @@ pre-commit run --all-files
 
 ## Workflow
 
-1. Sync and create a worktree before starting:
+1. From the main worktree, sync and create a new worktree:
 
    ```sh
-   cd ~/git/orbstack-kubernetes/main
    git fetch --prune origin && git pull
-   git worktree add ~/git/orbstack-kubernetes/<type>/<name> -b <type>/<name> main
+   git worktree add ../<type>/<name> -b <type>/<name> main
    ```
+
+   (The `../<type>/<name>` path keeps the worktree alongside `main/` in
+   whatever directory layout you use locally.)
 
 2. Make changes, then run unit tests (no cluster required):
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,17 @@ Kubernetes monitoring stack for local OrbStack cluster. Collects, processes, and
 
 ## Quick Start
 
-```bash
-# 1. Clone and enter repo
-cd ~/git/orbstack-kubernetes/main
+From a clone of this repo (any local path):
 
-# 2. Set up secrets (one-time)
+```bash
+# 1. Set up secrets (one-time)
 cp secrets.enc.yaml.example secrets.enc.yaml
 sops secrets.enc.yaml
 
-# 3. Deploy (Doppler exports CRIBL_DIST_MASTER_URL, project/config in SOPS)
+# 2. Deploy (Doppler exports CRIBL_DIST_MASTER_URL, project/config in SOPS)
 make deploy-doppler
 
-# 4. Verify
+# 3. Verify
 make status
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -55,7 +55,7 @@ make runner-uninstall-launchagent  # remove LaunchAgent
 
 - **Container failed?** `launchctl kickstart -k gui/$(id -u)/$(make -s runner-print-label)` forces the LaunchAgent to respawn the runner.
 - **Registration stuck?** Delete the orphan via `GH_TOKEN=$(doppler secrets get GH_PAT_RUNNER_TOKEN --plain -p gh-workflow-tokens -c prd) gh api -X DELETE "repos/${GITHUB_REPO}/actions/runners/<id>"`, then `launchctl kickstart -k ...`. Export `GITHUB_REPO` first or substitute your repo slug directly (e.g., from `make -n runner-status`).
-- **LaunchAgent not loaded?** Run `make runner-install-launchagent` from the worktree you want it to point at (typically `~/git/orbstack-kubernetes/main`).
+- **LaunchAgent not loaded?** Run `make runner-install-launchagent` from the worktree you want it to point at (usually the main worktree).
 - **Logs:** `~/Library/Logs/orbstack-runner/{stdout,stderr}.log`.
 
 The runner requires the macOS host to be powered on and OrbStack to be running. Sleep/wake and reboot are handled automatically by the LaunchAgent.


### PR DESCRIPTION
## Summary

User-facing docs shouldn't tell people where to clone the repo. This PR removes path-prefix references from `README.md`, `CONTRIBUTING.md`, and `docs/TESTING.md`.

## What changed

- **`README.md` Quick Start**: drop the leading `cd ${GIT_HOME_PUBLIC}/orbstack-kubernetes/main`. Replace with "From a clone of this repo (any local path):" — the `make` targets that follow run from the repo root.
- **`CONTRIBUTING.md` workflow**: drop the explicit `cd` step. From the main worktree, create a sibling worktree via `git worktree add ../<type>/<name> -b <type>/<name> main`. Relative path works regardless of where users keep their clones.
- **`docs/TESTING.md`** LaunchAgent troubleshooting: drop the parenthetical path; say "usually the main worktree" instead.

## Why this approach over earlier iterations

Original docs hard-coded `~/git/orbstack-kubernetes/...`. An earlier commit on this branch swapped those for `${GIT_HOME_PUBLIC}/orbstack-kubernetes/...` — which still presumed a specific workspace convention. Reviewer pushback: "The rest of the PR doesn't need local paths either. Come up with a way of rewriting so we don't need '~' OR `${GIT_HOME_PUBLIC}`." This rewrite removes the assumption entirely. Local path conventions belong in workspace tooling (nix-home sessionVariables, dotfiles), not in user-facing repo docs.

## Test plan

- [x] No `~/git/` or `${GIT_HOME` references remain in tracked `*.md` / `*.sh` / `*.yml` / `Makefile`
- [x] Pre-commit hooks pass
- [x] `git worktree add ../<type>/<name>` produces a sibling worktree alongside `main/` regardless of the parent directory's location (relative path semantics)

## Related

- nix-home v1.23.0 introducing `GIT_HOME` / `GIT_HOME_PUBLIC` sessionVariables (those vars still exist for cross-repo workspace tooling; this repo's docs just don't need to bake the convention in)
- Sibling sweep PRs in nix-darwin, nix-home, ai-assistant-instructions, claude-code-plugins

Assisted-by: Claude <noreply@anthropic.com>