### PR TITLE
fix(edge): patch pack FileMonitor patterns to match .jsonl session files

### DIFF
--- a/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
+++ b/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
@@ -78,6 +78,18 @@ spec:
                 /opt/cribl/bin/cribl pack install
                 -s https://github.com/JacobPEvans/cc-edge-vscode-io/releases/download/v1.0.1/cc-edge-vscode-io.crbl
                 || echo "WARNING: vscode-io pack install failed" >&2
+            # Local patch: gemini CLI 0.43.0 and Claude Code write .jsonl session
+            # files; the gemini-antigravity-io and claude-code-otel packs
+            # only match .json in their released versions.
+            # Remove these CMDs after pack releases add .jsonl natively.
+            - name: CRIBL_BEFORE_START_CMD_5
+              value: >-
+                grep -q 'session.*\.jsonl' /opt/cribl/data/default/cc-edge-gemini-antigravity/inputs.yml
+                || sed -i '/- ".*session.*\.json"/a\      - "*session-*.jsonl"' /opt/cribl/data/default/cc-edge-gemini-antigravity/inputs.yml
+            - name: CRIBL_BEFORE_START_CMD_6
+              value: >-
+                grep -q '\.jsonl' /opt/cribl/data/default/cc-edge-claude-code/inputs.yml
+                || sed -i '/- ".*\.json"/a\      - "*.jsonl"' /opt/cribl/data/default/cc-edge-claude-code/inputs.yml
           volumeMounts:
             - name: claude-logs
               mountPath: /home/claude/.claude

--- a/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
+++ b/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
@@ -85,11 +85,15 @@ spec:
             - name: CRIBL_BEFORE_START_CMD_5
               value: >-
                 grep -q 'session.*\.jsonl' /opt/cribl/data/default/cc-edge-gemini-antigravity/inputs.yml
-                || sed -i '/- ".*session.*\.json"/a\      - "*session-*.jsonl"' /opt/cribl/data/default/cc-edge-gemini-antigravity/inputs.yml
+                && exit 0;
+                sed -i '/- ".*session.*\.json"/a\      - "*session-*.jsonl"' /opt/cribl/data/default/cc-edge-gemini-antigravity/inputs.yml
+                || echo "WARNING: gemini jsonl pattern patch skipped (pack inputs.yml not present?)" >&2
             - name: CRIBL_BEFORE_START_CMD_6
               value: >-
                 grep -q '\.jsonl' /opt/cribl/data/default/cc-edge-claude-code/inputs.yml
-                || sed -i '/- ".*\.json"/a\      - "*.jsonl"' /opt/cribl/data/default/cc-edge-claude-code/inputs.yml
+                && exit 0;
+                sed -i '/- ".*\.json"/a\      - "*.jsonl"' /opt/cribl/data/default/cc-edge-claude-code/inputs.yml
+                || echo "WARNING: claude-code jsonl pattern patch skipped (pack inputs.yml not present?)" >&2
           volumeMounts:
             - name: claude-logs
               mountPath: /home/claude/.claude


### PR DESCRIPTION
## Summary

Local startup-time patch that appends `*session-*.jsonl` to the gemini pack's FileMonitor pattern after `cribl pack install` runs. Unblocks `test_gemini_session_sourcetype` which was failing because Gemini CLI 0.43.0 changed its session-file extension from `.json` to `.jsonl`.

## Why a local patch instead of upstream

I opened https://github.com/JacobPEvans/cc-edge-gemini-antigravity-io/pull/10 upstream with the same fix. Something running as the @JacobPEvans token (not the user directly) closed it without merging. While we figure that out, this in-repo patch unblocks E2E today.

## Changes

`k8s/monitoring/cribl-edge-standalone/statefulset.yaml`:
- `CRIBL_BEFORE_START_CMD_5` — `grep`-guarded `sed` that adds `*session-*.jsonl` to the gemini-antigravity-io pack's `inputs.yml`.
- `CRIBL_BEFORE_START_CMD_6` — same shape applied to the claude-code-otel pack. That pack already ships `*.jsonl` in v1.2.7, so the `grep` short-circuits and `sed` never runs — defensive only.

Both CMDs are idempotent (the `grep` guard prevents duplicate inserts across pod restarts).

## Removal plan

Delete CMD_5 once the cc-edge-gemini-antigravity-io pack ships a release that includes the `*session-*.jsonl` pattern natively. CMD_6 can be deleted any time — it's a future-defense no-op today.

## Test plan

- [x] `make validate` and `make validate-schemas` pass on the new manifest
- [x] Applied to live cluster; edge pod restarted cleanly
- [x] Verified patched `inputs.yml` in-pod has both `*session-*.json` and `*session-*.jsonl`
- [x] `make test-all` against the OrbStack cluster: **216 passed, 1 benign skip, 0 failed in 7m34s** (previously 215/216)
- [ ] CI validate + CI E2E green

## Related

- `JacobPEvans/cc-edge-gemini-antigravity-io#10` (upstream pack PR, closed by background automation; reopened in passing)
- `#250` (Makefile shebang fix — independent, also in flight)

Assisted-by: Claude <noreply@anthropic.com>