### PR TITLE
fix(idrac-webtop): handle '+' in JNLP filenames + pre-create config d…

### DIFF
--- a/docker/idrac-webtop/init/10-install-openwebstart.sh
+++ b/docker/idrac-webtop/init/10-install-openwebstart.sh
@@ -63,6 +63,17 @@ install -m 0644 /opt/idrac-payload/idrac-launch.desktop /usr/share/applications/
 update-desktop-database /usr/share/applications
 xdg-mime default idrac-launch.desktop application/x-java-jnlp-file
 
+# Pre-create the runtime state dir under abc ownership. If a root-owned
+# invocation ever races ahead of the first abc-owned one (e.g. someone runs
+# `docker exec idrac-webtop /usr/local/bin/idrac-launch ...` without `-u abc`),
+# subsequent abc-owned mkdir calls into /config/idrac-viewer/ fail with
+# "Permission denied". Pre-creating here eliminates the race and any stale
+# root-owned state from a prior container start.
+install -d -o abc -g abc /config/idrac-viewer /config/idrac-viewer/cache
+if [[ -d /config/idrac-viewer ]]; then
+  chown -R abc:abc /config/idrac-viewer
+fi
+
 # Seed the iDRAC bookmark + homepage via Firefox enterprise policies, and
 # wire Firefox's MIME handler so clicks on "Launch Virtual Console" pipe the
 # downloaded JNLP straight into idrac-launch (no Downloads/ detour, no prompt).

--- a/docker/idrac-webtop/payload/idrac-launch.sh
+++ b/docker/idrac-webtop/payload/idrac-launch.sh
@@ -94,13 +94,20 @@ fi
 # can still parse host:port out of it and compute URLPermissions correctly —
 # without that, the KVM viewer's SecurityManager rejects its own outbound
 # socket to <iDRAC>:5900 with "Connection failed" right after APCP version
-# negotiation. Also drop <icon>/<shortcut> so ITW doesn't trip on the iDRAC's
-# self-signed splash endpoint. All <argument> session tokens preserved.
+# negotiation. Also strip the root <jnlp href="..."> attribute so javaws
+# does not try to re-resolve the original download path — iDRAC 6 generates
+# href values containing literal '+' characters (URL-encoded spaces), and
+# javaws's URL parser decodes '+' back to space on the file:// side, yielding
+# a FileNotFoundException on a path that does exist on disk under its real
+# name. Dropping the attribute makes the JNLP self-contained. Also drop
+# <icon>/<shortcut> so ITW doesn't trip on the iDRAC's self-signed splash
+# endpoint. All <argument> session tokens preserved.
 REWRITTEN=$(mktemp --suffix=.jnlp)
 trap 'rm -f "$REWRITTEN"' EXIT
 
 sed -E \
   -e "s#href=\"https?://[^\"]*/([^/\"]+\\.jar)\"#href=\"file://$CACHE_DIR/\\1\"#g" \
+  -e 's/(<jnlp[^>]*) +href="[^"]*"/\1/' \
   -e '/<icon[^>]*\/>/d' \
   -e '/<shortcut[^>]*\/>/d' \
   -e '/<shortcut[^>]*>/,/<\/shortcut>/d' \


### PR DESCRIPTION
…ir as abc

Two latent bugs surfaced during 2026-05-26 R410 commissioning:

1. iDRAC 6's viewer.jnlp filename is URL-encoded (spaces → '+'). The root <jnlp ... href="viewer.jnlp(...)"> attribute carries that name verbatim. When the wrapper's rewritten temp JNLP is fed to javaws, javaws re-resolves the href via java.net.URL, which decodes '+' back to space, producing a FileNotFoundException on a path that does exist under its real name. Fix: strip the href attribute from the root <jnlp> tag in the rewrite step. The wrapper already produces a self-contained JNLP (jars rewritten to local file:// URLs), so dropping the root href just makes javaws stop trying to "refresh" itself from the original location.

2. If anything ever runs idrac-launch as root (e.g. `docker exec` without `-u abc`), the first invocation creates /config/idrac-viewer/ owned by root, and subsequent abc-owned invocations fail at mkdir with "Permission denied". Fix: pre-create the dir under abc:abc in the init hook, plus a defensive recursive chown so any stale root-owned state from a prior container start is corrected at every restart.

No behavior change in the happy path; both fixes only affect previously- broken edge cases.

Assisted-by: Claude <noreply@anthropic.com>