### PR TITLE
fix(ci): retarget reusable-workflow uses: refs to current org homes

### DIFF
--- a/.github/workflows/ai-all.yml
+++ b/.github/workflows/ai-all.yml
@@ -54,7 +54,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    uses: JacobPEvans/ai-workflows/.github/workflows/suite-all.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/suite-all.yml@main
     with:
       caller_event: ${{ github.event_name }}
       review_prompt: "Focus on Kubernetes monitoring patterns, OTEL collector configuration, Cribl Edge pipelines, and Helm chart best practices"

--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   ci-suite:
-    uses: JacobPEvans/ai-workflows/.github/workflows/suite-ci.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/suite-ci.yml@main
     with:
       repo_context: "Kubernetes monitoring stack for OrbStack (OTEL, Cribl Edge, Cribl Stream, Helm charts)"
       ci_structure: "validate.yml (Kubernetes manifest validation and linting)"

--- a/.github/workflows/ai-merge-gate.yml
+++ b/.github/workflows/ai-merge-gate.yml
@@ -3,5 +3,5 @@ on: pull_request
 permissions: read-all
 jobs:
   gate:
-    uses: JacobPEvans/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/_ai-merge-gate.yml@main
     secrets: inherit

--- a/.github/workflows/best-practices.yml
+++ b/.github/workflows/best-practices.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   best-practices:
-    uses: JacobPEvans/ai-workflows/.github/workflows/best-practices.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/best-practices.yml@main
     secrets: inherit

--- a/.github/workflows/ci-fail-issue.yml
+++ b/.github/workflows/ci-fail-issue.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   handle-failure:
     if: github.event.workflow_run.conclusion == 'failure'
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fail-issue.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fail-issue.yml@main
     with:
       workflow_name: "Validate"
     secrets: inherit

--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -28,7 +28,7 @@ jobs:
     #   github.event.workflow_run.conclusion == 'failure' &&
     #   github.event.workflow_run.head_branch != 'main'
     # --- END DISABLED ---
-    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/ci-fix.yml@main
     with:
       repo_context: "Kubernetes monitoring stack for OrbStack (OpenTelemetry, Cribl Edge, Cribl Stream)"
       ci_structure: "validate.yml (manifest validation and linting) + validate-merged.yml (post-merge validation)"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -190,13 +190,13 @@ jobs:
       - name: Install test dependencies
         run: make test-setup
       - name: Mask secrets
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           sops-file: secrets.enc.yaml
       - name: Deploy to OrbStack
         run: make deploy-doppler
       - name: Mask cluster IPs
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           mask-pod-ips: 'true'
           kubernetes-namespace: monitoring

--- a/.github/workflows/code-simplifier.yml
+++ b/.github/workflows/code-simplifier.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
   simplify:
-    uses: JacobPEvans/ai-workflows/.github/workflows/code-simplifier.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/code-simplifier.yml@main
     secrets: inherit

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Install test dependencies
         run: make test-setup
       - name: Mask secrets
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           sops-file: secrets.enc.yaml
       - name: Deploy to OrbStack
         run: make deploy-doppler
       - name: Mask cluster IPs
-        uses: JacobPEvans/.github/actions/mask-secrets@main
+        uses: JacobPEvans-personal/.github/actions/mask-secrets@main
         with:
           mask-pod-ips: 'true'
           kubernetes-namespace: monitoring

--- a/.github/workflows/final-pr-review.yml
+++ b/.github/workflows/final-pr-review.yml
@@ -18,5 +18,5 @@ permissions:
 
 jobs:
   review:
-    uses: JacobPEvans/ai-workflows/.github/workflows/final-pr-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/final-pr-review.yml@main
     secrets: inherit

--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_gh-aw-pin-refresh.yml@main
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:

--- a/.github/workflows/issue-auto-resolve.yml
+++ b/.github/workflows/issue-auto-resolve.yml
@@ -68,7 +68,7 @@ jobs:
 
   run-triage:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-triage.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-triage.yml@main
     secrets: inherit
     with:
       issue_number: ${{ inputs.issue_number }}
@@ -79,7 +79,7 @@ jobs:
       always() &&
       github.event_name == 'workflow_dispatch' &&
       (needs.run-triage.result == 'success' || needs.run-triage.result == 'skipped')
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-resolver.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-resolver.yml@main
     secrets: inherit
     with:
       repo_context: "Kubernetes monitoring stack for OrbStack (OTEL, Cribl Edge, Cribl Stream, Helm charts)"

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   hygiene:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-hygiene.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-hygiene.yml@main
     secrets: inherit

--- a/.github/workflows/issue-sweeper.yml
+++ b/.github/workflows/issue-sweeper.yml
@@ -12,5 +12,5 @@ permissions:
   pull-requests: read
 jobs:
   sweep:
-    uses: JacobPEvans/ai-workflows/.github/workflows/issue-sweeper.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/issue-sweeper.yml@main
     secrets: inherit

--- a/.github/workflows/next-steps.yml
+++ b/.github/workflows/next-steps.yml
@@ -17,5 +17,5 @@ concurrency:
 
 jobs:
   next-steps:
-    uses: JacobPEvans/ai-workflows/.github/workflows/next-steps.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/next-steps.yml@main
     secrets: inherit

--- a/.github/workflows/post-merge-docs-review.yml
+++ b/.github/workflows/post-merge-docs-review.yml
@@ -39,7 +39,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-docs-review.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -39,7 +39,7 @@ jobs:
 
   review:
     if: github.event_name == 'workflow_dispatch'
-    uses: JacobPEvans/ai-workflows/.github/workflows/post-merge-tests.yml@main
+    uses: dryvist/ai-workflows/.github/workflows/post-merge-tests.yml@main
     with:
       commit_sha: ${{ inputs.commit_sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Root cause

GitHub Actions `uses:` references are resolved at parse time with no redirect support and no variable interpolation. After the org migration, `JacobPEvans/ai-workflows` and `JacobPEvans/.github` no longer resolve — they must reference the current owner literally.

## Changes

Corrected 21 `uses:` lines across 18 workflow files:

| Old owner | New owner | Repo |
|---|---|---|
| `JacobPEvans/ai-workflows/` | `dryvist/ai-workflows/` | shared AI workflow suite |
| `JacobPEvans/.github/` | `JacobPEvans-personal/.github/` | shared actions (mask-secrets, release-please, gh-aw-pin-refresh) |

Path and `@ref` are unchanged on every line — owner swap only.

Skipped: 6 `.lock.yml` files (none contained real `uses:` lines).

Part of an org-wide sweep to fix all repos affected by the `JacobPEvans` → `dryvist` / `JacobPEvans-personal` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)