### PR TITLE
fix(dns): durable coredns internal-zone forward

### DIFF
--- a/k8s/coredns/coredns-custom.yaml
+++ b/k8s/coredns/coredns-custom.yaml
@@ -1,0 +1,23 @@
+# CoreDNS custom server block: forward the homelab internal DNS zone to the internal
+# DNS server so OrbStack pods resolve internal hostnames authoritatively, instead of via
+# the laptop's upstream resolver (which can serve a stale / split-horizon view).
+#
+# CoreDNS imports kube-system/coredns-custom keys matching *.server and reloads them
+# automatically (the cluster Corefile has `reload 15s`), so no CoreDNS restart needed.
+#
+# The zone and DNS-server address are SENSITIVE and must never be committed literally
+# (public repo). scripts/deploy.sh substitutes the placeholders from Doppler at deploy
+# time: __INTERNAL_DNS_ZONE__ <- PROXMOX_SUBDOMAIN, __INTERNAL_DNS_SERVER__ <- the .2
+# host of NETWORK_CIDR_DNS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  internal-zone.server: |
+    __INTERNAL_DNS_ZONE__:53 {
+        errors
+        cache 30
+        forward . __INTERNAL_DNS_SERVER__
+    }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -181,6 +181,25 @@ else
 fi
 echo ""
 
+# Step 2.4: CoreDNS internal-zone forward.
+# OrbStack pods otherwise resolve internal hostnames via the laptop's upstream resolver,
+# which can serve a stale/split-horizon view; forward the internal zone straight to the
+# internal DNS server for authoritative resolution. Zone + server come from Doppler
+# (PROXMOX_SUBDOMAIN, NETWORK_CIDR_DNS) — never committed literally.
+echo "--- Step 2.4: Applying CoreDNS internal-zone forward ---"
+if [ -n "${PROXMOX_SUBDOMAIN:-}" ] && [ -n "${NETWORK_CIDR_DNS:-}" ]; then
+  IFS=./ read -r _dns_o1 _dns_o2 _dns_o3 _ <<< "$NETWORK_CIDR_DNS"
+  INTERNAL_DNS_SERVER="${_dns_o1}.${_dns_o2}.${_dns_o3}.2"
+  sed -e "s|__INTERNAL_DNS_ZONE__|${PROXMOX_SUBDOMAIN}|g" \
+      -e "s|__INTERNAL_DNS_SERVER__|${INTERNAL_DNS_SERVER}|g" \
+      "$REPO_ROOT/k8s/coredns/coredns-custom.yaml" \
+    | kubectl --context "$CONTEXT" apply -f -
+  echo "  Applied: coredns-custom (internal-zone DNS forward; CoreDNS reload picks it up)"
+else
+  echo "  SKIPPED: coredns-custom (PROXMOX_SUBDOMAIN or NETWORK_CIDR_DNS not set)"
+fi
+echo ""
+
 # Step 2.5: Apply Doppler operator resources (CRDs not in kustomize base)
 echo "--- Step 2.5: Applying Doppler operator resources ---"
 if kubectl --context "$CONTEXT" api-resources --api-group=secrets.doppler.com 2>/dev/null | grep -q DopplerSecret; then


### PR DESCRIPTION
## What

Adds a committed `coredns-custom` configmap (kube-system) that forwards the homelab internal DNS zone to the internal DNS server, and wires `deploy.sh` to substitute the zone + server from Doppler at deploy time.

## Why

OrbStack pods resolve internal hostnames via the laptop's upstream resolver, which can serve a stale / split-horizon view. Forwarding the internal zone straight to the internal DNS server gives authoritative resolution. This replaces a **runtime-only** configmap so the fix survives `make deploy`.

## How

- `k8s/coredns/coredns-custom.yaml`: CoreDNS imports `kube-system/coredns-custom` keys matching `*.server` and auto-reloads (cluster Corefile has `reload 15s`) — no CoreDNS restart.
- `scripts/deploy.sh` (Step 2.4): derives the zone from `PROXMOX_SUBDOMAIN` and the DNS server from `NETWORK_CIDR_DNS` (Doppler), `sed`-substitutes the placeholders, applies to kube-system. **Placeholders only — no literal domain/IP committed.**

Verified: substitution renders valid YAML; `kubectl apply --dry-run=client` passes.