### PR TITLE
feat(cribl-edge): ship bifrost pod logs to the homelab Stream (index=llm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Kubernetes monitoring stack for local OrbStack cluster. Collects, processes, and
 | Cribl MCP Server | Cribl Cloud MCP API server for Claude Code | 30030 (NodePort) |
 | AI Jobs | Ephemeral Claude Code / Gemini CLI containers | N/A |
 
+> **Fleet policy**: Cribl Cloud fleets are reserved for Linux machines
+> (VMs/containers/servers). The managed Edge in this cluster qualifies
+> (Linux containers); macOS hosts run standalone, GitOps-managed Edge nodes.
+
 ## Quick Start
 
 From a clone of this repo (any local path):

--- a/k8s/monitoring/cribl-edge-standalone/inputs.yml
+++ b/k8s/monitoring/cribl-edge-standalone/inputs.yml
@@ -1,0 +1,17 @@
+inputs:
+  in_bifrost_pod_logs:
+    type: file
+    disabled: false
+    mode: manual
+    filenames:
+      - /var/log/pods/monitoring_bifrost-*/**/*.log
+    # Index/sourcetype stamped at the source; the homelab Stream passes
+    # events straight through to Splunk.
+    metadata:
+      - name: index
+        value: "'llm'"
+      - name: sourcetype
+        value: "'bifrost'"
+    sendToRoutes: false
+    connections:
+      - output: proxmox-stream

--- a/k8s/monitoring/cribl-edge-standalone/kustomization.yaml
+++ b/k8s/monitoring/cribl-edge-standalone/kustomization.yaml
@@ -15,3 +15,4 @@ configMapGenerator:
     files:
       - outputs.yml=outputs.yml
       - limits.yml=limits.yml
+      - inputs.yml=inputs.yml

--- a/k8s/monitoring/cribl-edge-standalone/outputs.yml
+++ b/k8s/monitoring/cribl-edge-standalone/outputs.yml
@@ -13,6 +13,16 @@ outputs:
     pqEnabled: true
     pqMaxSize: "2GB"
     pqPath: /opt/cribl/data/pq
+  proxmox-stream:
+    # Cribl TCP (S2S) to the homelab HAProxy-fronted Cribl Stream workers.
+    # PLACEHOLDER_CRIBL_S2S_HOST is replaced at container start from the
+    # CRIBL_S2S_HOST env var (see statefulset CRIBL_BEFORE_START_CMD).
+    type: cribl_tcp
+    host: PLACEHOLDER_CRIBL_S2S_HOST
+    port: 10300
+    pqEnabled: true
+    pqMaxSize: "1GB"
+    pqPath: /opt/cribl/data/pq-proxmox
   default:
     type: default
     defaultId: stream-hec

--- a/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
+++ b/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
@@ -54,12 +54,20 @@ spec:
               value: "/home/vscode"
             - name: CRIBL_EDGE_API_HOST
               value: "0.0.0.0"
+            # Homelab Cribl S2S endpoint (HAProxy-fronted Stream workers).
+            # Bare hostname resolves via the host resolver; override with an
+            # FQDN in a local overlay if single-label lookup fails.
+            - name: CRIBL_S2S_HOST
+              value: "haproxy"
             - name: CRIBL_BEFORE_START_CMD_1
               value: >-
                 find ${CRIBL_VOLUME_DIR}/data -depth -delete 2>/dev/null;
                 mkdir -p ${CRIBL_VOLUME_DIR}/local/edge &&
-                rm -f ${CRIBL_VOLUME_DIR}/local/edge/inputs.yml &&
+                cp /var/tmp/cribl-config/inputs.yml
+                ${CRIBL_VOLUME_DIR}/local/edge/inputs.yml &&
                 cp /var/tmp/cribl-config/outputs.yml
+                ${CRIBL_VOLUME_DIR}/local/edge/outputs.yml &&
+                sed -i "s/PLACEHOLDER_CRIBL_S2S_HOST/${CRIBL_S2S_HOST}/"
                 ${CRIBL_VOLUME_DIR}/local/edge/outputs.yml &&
                 cp /var/tmp/cribl-config/limits.yml
                 ${CRIBL_VOLUME_DIR}/local/edge/limits.yml
@@ -118,6 +126,9 @@ spec:
               readOnly: true
             - name: vscode-extensions
               mountPath: /home/vscode/.vscode
+              readOnly: true
+            - name: pod-logs
+              mountPath: /var/log/pods
               readOnly: true
             - name: cribl-config-templates
               mountPath: /var/tmp/cribl-config
@@ -198,6 +209,10 @@ spec:
           hostPath:
             path: PLACEHOLDER_HOME_DIR/.vscode
             type: DirectoryOrCreate
+        - name: pod-logs
+          hostPath:
+            path: /var/log/pods
+            type: Directory
         - name: cribl-config-templates
           configMap:
             name: cribl-edge-standalone-config

--- a/scripts/generate-overlay.sh
+++ b/scripts/generate-overlay.sh
@@ -136,6 +136,10 @@ spec:
           hostPath:
             path: ${HOME_DIR}/.vscode
             type: DirectoryOrCreate
+        - name: pod-logs
+          hostPath:
+            path: /var/log/pods
+            type: Directory
         - name: cribl-config-templates
           configMap:
             name: cribl-edge-standalone-config


### PR DESCRIPTION
## What

- Standalone Edge gains an `inputs.yml` (via the existing configmap): file source over `/var/log/pods/monitoring_bifrost-*/**/*.log`, stamping `index=llm` / `sourcetype=bifrost` at the source.
- New `cribl_tcp` output `proxmox-stream` to the HAProxy-fronted homelab Cribl Stream workers on :10300 (persistent queue on). Host comes from `CRIBL_S2S_HOST` (default `haproxy`), substituted at container start; override in a local overlay if single-label DNS doesn't resolve from pods.
- `/var/log/pods` mounted read-only in the statefulset and the overlay generator (same pattern the OTEL collector already uses).

## How

The bifrost gateway's container logs only exist on the k8s node; the standalone Edge reads them as files and ships them through the same Edge→HAProxy→Stream→Splunk path used by other remote Edge senders (dryvist/ansible-proxmox-apps#393, dryvist/terraform-proxmox#424; destination index in dryvist/ansible-splunk#246).

## Apply

`make deploy-doppler` (regenerates the overlay, applies kustomize).

## Verify

`kubectl kustomize k8s/monitoring` builds (checked); after deploy: Edge UI shows the input reading and the output connected; Splunk `index=llm sourcetype=bifrost`.

Refs: dryvist/ansible-proxmox-apps#393, dryvist/terraform-proxmox#424, dryvist/ansible-splunk#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)