### PR TITLE
fix(cribl-edge): proxmox-stream output must be tcpjson — receiver is single-instance

### DIFF
--- a/k8s/monitoring/cribl-edge-standalone/outputs.yml
+++ b/k8s/monitoring/cribl-edge-standalone/outputs.yml
@@ -1,10 +1,13 @@
 outputs:
   proxmox-stream:
-    # Cribl TCP (S2S) to the homelab HAProxy-fronted Cribl Stream workers.
+    # TCP JSON (S2S) to the homelab HAProxy-fronted Cribl Stream workers.
+    # tcpjson, not cribl_tcp: the receiving Stream is single-instance, where
+    # Cribl only permits the TCP JSON source ("Source is not allowed in this
+    # deployment" otherwise) — the homelab input is tcpjson on the same port.
     # PLACEHOLDER_CRIBL_S2S_HOST is replaced at container start from the
     # CRIBL_S2S_HOST env var (see statefulset CRIBL_BEFORE_START_CMD).
     # The sole egress path for ALL Edge telemetry — the laptop runs no Stream.
-    type: cribl_tcp
+    type: tcpjson
     host: PLACEHOLDER_CRIBL_S2S_HOST
     port: 10300
     # Output-conditioning pipeline: stamps Splunk index/sourcetype (from

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -81,7 +81,10 @@ class TestArchitectureInvariant:
         outputs = yaml.safe_load((EDGE_STANDALONE_DIR / "outputs.yml").read_text())["outputs"]
 
         proxmox_stream = outputs["proxmox-stream"]
-        assert proxmox_stream["type"] == "cribl_tcp", "proxmox-stream output must be Cribl S2S (cribl_tcp)"
+        assert proxmox_stream["type"] == "tcpjson", (
+            "proxmox-stream output must be tcpjson — the homelab Stream is single-instance, "
+            "where Cribl only permits the TCP JSON source (cribl_tcp is distributed-only)"
+        )
         assert proxmox_stream["host"] == "PLACEHOLDER_CRIBL_S2S_HOST", (
             "proxmox-stream host must be the PLACEHOLDER_CRIBL_S2S_HOST placeholder "
             "(substituted from CRIBL_S2S_HOST at container start) — never a real host"


### PR DESCRIPTION
## Why

Deploying the homelab S2S listener surfaced a Cribl product limit: the **Cribl TCP source is only available in distributed Stream deployments** ([Cribl docs](https://docs.cribl.io/stream/sources-cribl-tcp/)). The homelab Stream is single-instance, so its `cribl_tcp` input failed with `Source is not allowed in this deployment` and :10300 never bound. The receiving side is being switched to Cribl's documented single-instance equivalent, the TCP JSON source (dryvist/ansible-proxmox-apps#408); this PR switches the Edge's sending side to the matching `tcpjson` destination.

## What changed

- `k8s/monitoring/cribl-edge-standalone/outputs.yml`: `proxmox-stream` type `cribl_tcp` → `tcpjson` (same host placeholder, port 10300, force-splunk-meta pipeline, PQ).
- `tests/test_manifests.py`: invariant updated to assert `tcpjson` with the rationale.

TCP JSON doesn't carry Cribl *internal* fields, which we don't rely on — index/sourcetype are stamped as regular event fields by the force-splunk-meta output pipeline (#272).

## Verification

Manifest tests pass (18/18). Post-merge: `make deploy`, then a sentinel event must reach Splunk via the homelab path.

Refs: #272, dryvist/ansible-proxmox-apps#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)