### PR TITLE
fix(cribl-edge): seed S2S endpoint FQDN from a persisted secret

### DIFF
--- a/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
+++ b/k8s/monitoring/cribl-edge-standalone/statefulset.yaml
@@ -61,10 +61,18 @@ spec:
             - name: CRIBL_EDGE_API_HOST
               value: "0.0.0.0"
             # Homelab Cribl S2S endpoint (HAProxy-fronted Stream workers).
-            # Bare hostname resolves via the host resolver; override with an
-            # FQDN in a local overlay if single-label lookup fails.
+            # Single-label names do NOT resolve in-cluster (cluster DNS search
+            # domains don't cover the internal zone), so the FQDN lives in the
+            # persisted cribl-s2s-config secret, seeded by deploy.sh from
+            # CRIBL_S2S_HOST (SOPS) — same pattern as splunk-hec-config.
+            # Optional: without the secret the before-start sed falls back to
+            # the bare name.
             - name: CRIBL_S2S_HOST
-              value: "haproxy"
+              valueFrom:
+                secretKeyRef:
+                  name: cribl-s2s-config
+                  key: host
+                  optional: true
             - name: CRIBL_BEFORE_START_CMD_1
               value: >-
                 find ${CRIBL_VOLUME_DIR}/data -depth -delete 2>/dev/null;
@@ -73,7 +81,7 @@ spec:
                 ${CRIBL_VOLUME_DIR}/local/edge/inputs.yml &&
                 cp /var/tmp/cribl-config/outputs.yml
                 ${CRIBL_VOLUME_DIR}/local/edge/outputs.yml &&
-                sed -i "s/PLACEHOLDER_CRIBL_S2S_HOST/${CRIBL_S2S_HOST}/"
+                sed -i "s/PLACEHOLDER_CRIBL_S2S_HOST/${CRIBL_S2S_HOST:-haproxy}/"
                 ${CRIBL_VOLUME_DIR}/local/edge/outputs.yml &&
                 cp /var/tmp/cribl-config/limits.yml
                 ${CRIBL_VOLUME_DIR}/local/edge/limits.yml &&

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,6 +47,19 @@ else
   echo "  SKIPPED: cribl-edge-admin (CRIBL_EDGE_PASSWORD not set, using default)"
 fi
 
+# Homelab Cribl S2S endpoint (HAProxy FQDN — single-label names don't resolve
+# in-cluster). Persisted as a secret so a plain `make deploy` without the SOPS
+# env keeps the previously seeded endpoint instead of regressing.
+if [ -n "${CRIBL_S2S_HOST:-}" ]; then
+  kubectl --context "$CONTEXT" create secret generic cribl-s2s-config \
+    --namespace "$NAMESPACE" \
+    --from-literal=host="$CRIBL_S2S_HOST" \
+    --dry-run=client -o yaml | kubectl --context "$CONTEXT" apply -f -
+  echo "  Created: cribl-s2s-config"
+else
+  echo "  SKIPPED: cribl-s2s-config (CRIBL_S2S_HOST not set; existing secret kept)"
+fi
+
 # Splunk HEC config (standalone edge)
 # Derive HEC URL from SPLUNK_NETWORK terraform output (JSON array, e.g. '["192.168.0.200"]')
 SPLUNK_HEC_URL=""

--- a/secrets.enc.yaml
+++ b/secrets.enc.yaml
@@ -15,10 +15,10 @@ HEALTHCHECKS_SPLUNK_URL: ENC[AES256_GCM,data:HheKtO0iXSg7qeLzhybQgZ1Kcebts1GGz+H
 HEALTHCHECKS_EDGE_URL: ENC[AES256_GCM,data:0Pphsv13Nn8iQHeI3n+5bbkjnzc2sPRU+YBZxpGvsMEk6mds9FnVoDGUa2oTxsBkM6eXK+MYtDpb,iv:efekL91qxnUxaBd5/AT3TcVJXJ7wPnw/1X8QtjbsHZ8=,tag:xPySkzLb/MWgW5cCHDby7w==,type:str]
 HEALTHCHECKS_OTEL_URL: ENC[AES256_GCM,data:MWZAS2MngZeKqV/zL57DJvrX6IQTLZPal54rG8I7MmbM2a9+kc9J9114JLUCAiqItla3N/53X8skeRZNuA==,iv:bo5GwUQfkkCjWOxSMmEySb6f0kwvO8JUDnqeH9JZcq4=,tag:vRJRki3rvnJtiPRlgJRcGQ==,type:str]
 DOPPLER_TOKEN: ENC[AES256_GCM,data:Cc/Ml65Y884WrOTgKbHV/Vfaq2KJDDw/UlczTmgtgUD1mbfYWvtRiRvziXl1DYGIT5UDZrU=,iv:/jEBDbDLX+lDxxKJgsN8zG0viIL3qtFE7kFLQPAFSvs=,tag:/tC/VEM+Qp+UgHA/oSOvfw==,type:str]
+CRIBL_S2S_HOST: ENC[AES256_GCM,data:RuAMQ+NICtwSNBTStwUsGRezcMkZiwzz0Tf5,iv:0YVcTYS2hoJ0RsKMoCOq9ulVnOn8KfsRhUp6zWLlp9s=,tag:WjsBZT5g729DbHB79QWltQ==,type:str]
 sops:
     age:
-        - recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzQWVuTmFxeUFGdE10a3BW
             bmdZVkFuaGhzYW1rSVdqT3ZWdHVzV3NFZGxrCmpIL2dwblAwWG1qZW42b0dwU2xH
@@ -26,7 +26,8 @@ sops:
             S0NNUTZMRnNuSmVucktlWWNFMXBwM1EKCoKIojKUBet7tEiclGU/OOmpRYCjumr5
             WeHWuNXyzG2EEaD1huArfuK60wkQXysUDq/GXMV4E/roX4mr2iiJqA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-07T17:18:42Z"
-    mac: ENC[AES256_GCM,data:BDXgykVtKT9BNSynvduGgMIGfS1dmD9Iov3HkP3Lv+Pqky0kEYwVDFExTC8TxSuUTeV6ae/9tti3OJE80Ff3Vcs9AX78yXHkovYL7QhPXYUOaENYazc9HGNrK7nxj5FA1UISNf24mjyk5BuPPvWorPfMvKD/WobLpasIO70EXGo=,iv:OZjNqZwoH6sB4hvc3uBMzUj6alDZnDg1GQxn5zqYN1s=,tag:A2WapREBY/9poScSivUnfg==,type:str]
+          recipient: age1y0jvtlp2ac8fwwvh2nzm88ehye74jlseywjrjcjqll7u8vycsedq788tp9
+    lastmodified: "2026-06-12T20:33:31Z"
+    mac: ENC[AES256_GCM,data:iMYgMMM91DIkQds+ULrRhX96M/30pfoqW3uTaTjHHaCM8/uHtQkrsGhl2dtEetxFGnvNB/Z3dpoa61pZ14G14q9gi18KDiSH76PeOzJGyVEl9FJL+R/6c98LJraL0wfoCR+Osezn1NbXwubBMEZlUUx4r9RzImLQ2H0u3AggmSE=,iv:wwDgfm28gXGbgZSF57to/sSow7BXAuEOyVd65AJOkVg=,tag:qAm0FdWNBqor7arJ3whlAA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/secrets.enc.yaml.example
+++ b/secrets.enc.yaml.example
@@ -16,6 +16,11 @@ CRIBL_CLOUD_MASTER_URL: "tls://your-token-here@your-org.cribl.cloud:4200?group=d
 # URL is derived at deploy time from SPLUNK_NETWORK terraform output
 SPLUNK_HEC_TOKEN: "your-splunk-hec-token-here"
 
+# Homelab Cribl S2S endpoint: FQDN of the HAProxy fronting the Stream workers.
+# Must be a fully qualified name — single-label hostnames do not resolve from
+# inside the cluster. Seeded into the cribl-s2s-config secret at deploy time.
+CRIBL_S2S_HOST: "haproxy.example.net"
+
 # AI container API keys (for ephemeral job containers)
 CLAUDE_API_KEY: "your-claude-api-key-here"
 GEMINI_API_KEY: "your-gemini-api-key-here"


### PR DESCRIPTION
## Problem

The committed `CRIBL_S2S_HOST` default is a bare single-label hostname. Single-label names do not resolve from inside the cluster (cluster DNS search domains don't cover the internal zone), so the `proxmox-stream` tcpjson output could never connect — every Edge event sat in the persistent queue and nothing reached the homelab Stream. Found during the 2.0.1 cutover deploy: `sending is blocked` / `attempting to connect` loop in the Edge log, `getent` confirming no resolution in-pod.

## Fix (mirrors the existing `splunk-hec-config` pattern)

- **statefulset**: `CRIBL_S2S_HOST` now comes from a `cribl-s2s-config` secret (`optional: true`); the before-start `sed` falls back to the bare name when the secret is absent.
- **deploy.sh**: seeds `cribl-s2s-config` from `CRIBL_S2S_HOST` when set; a plain `make deploy` without the SOPS env **keeps the existing secret** instead of regressing the endpoint.
- **secrets.enc.yaml(.example)**: adds `CRIBL_S2S_HOST` (FQDN, SOPS-encrypted in the real file).

## Verified

With the FQDN in place (interim `kubectl set env` + the seeded secret), the full chain is live: Edge log shows `connected` to :10300, and a sentinel HEC event posted to the Edge NodePort landed in Splunk with index/sourcetype intact in ~1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)