### PR TITLE
fix(makefile): power-save suspends heartbeat CronJobs; correct runner repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 
 CONTEXT ?= orbstack
 NAMESPACE := monitoring
-GITHUB_REPO ?= JacobPEvans/orbstack-kubernetes
+GITHUB_REPO ?= dryvist/orbstack-kubernetes
 KUSTOMIZE_DIRS := k8s/monitoring
 MONITORING_STATEFULSETS := otel-collector cribl-edge-managed cribl-edge-standalone cribl-mcp-server bifrost
+MONITORING_CRONJOBS := heartbeat-edge heartbeat-otel heartbeat-splunk pipeline-heartbeat
 
 # Virtual environment configuration
 VENV ?= .venv
@@ -108,11 +109,19 @@ warmup: ## Send warmup trace to prime OTEL gRPC connection (retries 3x)
 power-save: ## Scale all monitoring pods to 0 replicas (battery saver)
 	@echo "Scaling down monitoring stack..."
 	kubectl --context $(CONTEXT) -n $(NAMESPACE) scale statefulset $(MONITORING_STATEFULSETS) --replicas=0
-	@echo "All monitoring pods scaled to 0. Run 'make full-power' to restore."
+	@echo "Suspending heartbeat CronJobs..."
+	@for cj in $(MONITORING_CRONJOBS); do \
+		kubectl --context $(CONTEXT) -n $(NAMESPACE) patch cronjob $$cj -p '{"spec":{"suspend":true}}'; \
+	done
+	@echo "All monitoring pods scaled to 0 + CronJobs suspended. Run 'make full-power' to restore."
 
 full-power: ## Scale all monitoring pods to 1 replica (full power)
 	@echo "Scaling up monitoring stack..."
 	kubectl --context $(CONTEXT) -n $(NAMESPACE) scale statefulset $(MONITORING_STATEFULSETS) --replicas=1
+	@echo "Resuming heartbeat CronJobs..."
+	@for cj in $(MONITORING_CRONJOBS); do \
+		kubectl --context $(CONTEXT) -n $(NAMESPACE) patch cronjob $$cj -p '{"spec":{"suspend":false}}'; \
+	done
 	@echo "Waiting for rollouts..."
 	@for sts in $(MONITORING_STATEFULSETS); do \
 		kubectl --context $(CONTEXT) -n $(NAMESPACE) rollout status statefulset/$$sts --timeout=120s; \


### PR DESCRIPTION
## What

Two Makefile fixes:

1. **`power-save` now suspends the heartbeat CronJobs** (`heartbeat-edge`, `heartbeat-otel`,
   `heartbeat-splunk`, `pipeline-heartbeat`); `full-power` resumes them. Previously
   `power-save` scaled the monitoring statefulsets to 0 but left the CronJobs firing every
   5 min against the now-absent services — they failed and piled up `Error` pods, churning
   the control plane. New `MONITORING_CRONJOBS` var drives both targets.

2. **`GITHUB_REPO` → `dryvist/orbstack-kubernetes`** (was `JacobPEvans/...`). The self-hosted
   runner's registration `POST /actions/runner-registration` returns 404 against the old
   name — the runner-registration API doesn't follow the org rename redirect — so the runner
   couldn't register. Aligning to the current repo fixes registration (and `runner-doctor-github`).

## Validation
- `make -n power-save` / `make -n full-power` expand the new `patch cronjob ... suspend`
  commands; Makefile parses clean.
- Live: heartbeat CronJobs suspended + the accumulated failed pods cleared (control-plane
  churn gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)