### PR TITLE
docs(readme): normalize headings to Installation/Usage; add hub footer

### DIFF
--- a/.readme-validator.yaml
+++ b/.readme-validator.yaml
@@ -1,3 +1,3 @@
 required_sections:
-  - Quick Start
-  - Architecture
+  - Installation
+  - Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Kubernetes monitoring stack for local OrbStack cluster. Collects, processes, and
 > (VMs/containers/servers). The managed Edge in this cluster qualifies
 > (Linux containers); macOS hosts run standalone, GitOps-managed Edge nodes.
 
-## Quick Start
+## Installation
 
 From a clone of this repo (any local path):
 
@@ -92,7 +92,7 @@ orbstack-kubernetes/
 └── Makefile
 ```
 
-## Make Targets
+## Usage
 
 | Target | Description |
 |--------|-------------|
@@ -140,3 +140,7 @@ direnv allow                     # one-time per worktree
 - [Deployment Guide](docs/DEPLOYMENT.md)
 - [Troubleshooting](docs/TROUBLESHOOTING.md)
 - [AI Containers](docs/AI-CONTAINERS.md)
+
+---
+
+> Part of a [larger ecosystem of ~40 repos](https://docs.jacobpevans.com) — see how it all fits together.


### PR DESCRIPTION
## Summary

Per the [README standard](https://docs.jacobpevans.com/conventions/readme-conventions):

- No sibling-repo narrative to remove (Cribl/OTEL/Splunk are services; the data flow is this stack's own output contract).
- Normalized headings for portfolio uniformity: `Quick Start` → `Installation`, `Make Targets` → `Usage`; aligned `.readme-validator.yaml` to the standard default.
- Added the single hub footer.

## Linear

JAC-141

## Test plan

- [x] README validator exits 0 (Installation + Usage present)
- [x] grep: no sibling-repo references