### PR TITLE
docs: genericize leaked Doppler project names in docs and scripts

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -64,7 +64,7 @@ The runner requires the macOS host to be powered on and OrbStack to be running. 
 
 - Test venv installed: `make test-setup`
 - For Tiers 1–4 (local only): OrbStack running with monitoring namespace deployed: `make deploy-doppler`
-- Splunk HEC token configured: `SPLUNK_HEC_TOKEN` must be set in Doppler `iac-conf-mgmt/prd`
+- Splunk HEC token configured: `SPLUNK_HEC_TOKEN` must be set in the infrastructure Doppler project
 - Splunk management credentials in secret: `splunk-hec-config` must have `mgmt-url` and `admin-password` keys (populated automatically by `make deploy-doppler` when `SPLUNK_PASSWORD` is set)
 
 ## Test Files
@@ -153,7 +153,7 @@ The `splunk-hec-config` secret is missing `mgmt-url` or `admin-password` keys. R
 make deploy-doppler
 ```
 
-Requires `SPLUNK_PASSWORD` and `SPLUNK_NETWORK` set in Doppler `iac-conf-mgmt/prd`.
+Requires `SPLUNK_PASSWORD` and `SPLUNK_NETWORK` set in the infrastructure Doppler project.
 
 ### `test_file_events_reach_splunk_realtime` fails (sentinel not in Splunk)
 

--- a/scripts/deploy-doppler.sh
+++ b/scripts/deploy-doppler.sh
@@ -23,6 +23,8 @@ fi
 
 # Fetch MCP secrets from the Cribl/cloud Doppler project (CRIBL_BASE_URL, CRIBL_CLIENT_ID, CRIBL_CLIENT_SECRET).
 # These supplement the main infrastructure Doppler secrets (which provide DEFAULT_PASSWORD → MCP_API_KEY).
-eval "$(doppler "${DOPPLER_OPTS[@]}" secrets download --project "${CRIBL_MCP_DOPPLER_PROJECT:?CRIBL_MCP_DOPPLER_PROJECT must be set}" --config "${CRIBL_MCP_DOPPLER_CONFIG:?CRIBL_MCP_DOPPLER_CONFIG must be set}" --format env --no-file 2>/dev/null)" || true
+: "${CRIBL_MCP_DOPPLER_PROJECT:?CRIBL_MCP_DOPPLER_PROJECT must be set}"
+: "${CRIBL_MCP_DOPPLER_CONFIG:?CRIBL_MCP_DOPPLER_CONFIG must be set}"
+eval "$(doppler "${DOPPLER_OPTS[@]}" secrets download --project "$CRIBL_MCP_DOPPLER_PROJECT" --config "$CRIBL_MCP_DOPPLER_CONFIG" --format env --no-file 2>/dev/null)" || true
 
 doppler "${DOPPLER_OPTS[@]}" run --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" -- "$SCRIPT_DIR/deploy.sh"

--- a/scripts/deploy-doppler.sh
+++ b/scripts/deploy-doppler.sh
@@ -21,8 +21,8 @@ if [ -n "${DOPPLER_TOKEN:-}" ]; then
   DOPPLER_OPTS=(--config-dir "$_DOPPLER_TMP_CFG")
 fi
 
-# Fetch MCP secrets from cloud-secrets project (CRIBL_BASE_URL, CRIBL_CLIENT_ID, CRIBL_CLIENT_SECRET).
-# These supplement the main iac-conf-mgmt secrets (which provide DEFAULT_PASSWORD → MCP_API_KEY).
-eval "$(doppler "${DOPPLER_OPTS[@]}" secrets download --project "${CRIBL_MCP_DOPPLER_PROJECT:-cloud-secrets}" --config "${CRIBL_MCP_DOPPLER_CONFIG:-prd}" --format env --no-file 2>/dev/null)" || true
+# Fetch MCP secrets from the Cribl/cloud Doppler project (CRIBL_BASE_URL, CRIBL_CLIENT_ID, CRIBL_CLIENT_SECRET).
+# These supplement the main infrastructure Doppler secrets (which provide DEFAULT_PASSWORD → MCP_API_KEY).
+eval "$(doppler "${DOPPLER_OPTS[@]}" secrets download --project "${CRIBL_MCP_DOPPLER_PROJECT:?CRIBL_MCP_DOPPLER_PROJECT must be set}" --config "${CRIBL_MCP_DOPPLER_CONFIG:?CRIBL_MCP_DOPPLER_CONFIG must be set}" --format env --no-file 2>/dev/null)" || true
 
 doppler "${DOPPLER_OPTS[@]}" run --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" -- "$SCRIPT_DIR/deploy.sh"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -114,7 +114,7 @@ else
   echo "  SKIPPED: heartbeat-config (no HEALTHCHECKS_*_URL set)"
 fi
 
-# Cribl MCP server config (CRIBL_BASE_URL from cloud-secrets, MCP_API_KEY from iac-conf-mgmt DEFAULT_PASSWORD)
+# Cribl MCP server config (CRIBL_BASE_URL from the Cribl/cloud Doppler project, MCP_API_KEY from the infrastructure Doppler project's DEFAULT_PASSWORD)
 MCP_BASE_URL="${CRIBL_BASE_URL:-}"
 if [ -n "$MCP_BASE_URL" ]; then
   MCP_ARGS=(--from-literal=base-url="$MCP_BASE_URL")
@@ -128,11 +128,11 @@ if [ -n "$MCP_BASE_URL" ]; then
   echo "  Created: cribl-mcp-config"
 else
   echo "  SKIPPED: cribl-mcp-config (CRIBL_BASE_URL not set)"
-  echo "           Set CRIBL_BASE_URL in Doppler cloud-secrets/prd, or use: make deploy-doppler"
+  echo "           Set CRIBL_BASE_URL in the Cribl/cloud Doppler project, or use: make deploy-doppler"
 fi
 
 # Ensure Splunk license is current (prevents search failures from expired licenses).
-# SPLUNK_LICENSE contains the full license XML from Doppler iac-conf-mgmt/prd.
+# SPLUNK_LICENSE contains the full license XML from the infrastructure Doppler project.
 if [ -n "${SPLUNK_LICENSE:-}" ] && [ -n "${SPLUNK_IP:-}" ] && [ -n "${SPLUNK_PASSWORD:-}" ]; then
   if curl -sk "https://${SPLUNK_IP}:8089/services/licenser/licenses" \
     -u "admin:${SPLUNK_PASSWORD}" \


### PR DESCRIPTION
## Summary

Scrubs hardcoded Doppler project names out of committed files in this public repo. The leaks were in **comments, prose, and one fallback default** — never in functional behavior (scripts already read `DOPPLER_PROJECT`/`DOPPLER_CONFIG` from the environment).

### Changes

- **Comments / prose** in `docs/TESTING.md`, `scripts/deploy-doppler.sh`, `scripts/deploy.sh` now refer to "the infrastructure Doppler project" and "the Cribl/cloud Doppler project" instead of literal project names.
- A token-secret reference in prose was genericized to `DOPPLER_TOKEN`.
- Env-var **names** (`DOPPLER_PROJECT`, `CRIBL_MCP_DOPPLER_PROJECT`, `MCP_API_KEY`, `SPLUNK_LICENSE`, etc.) are unchanged — only literal vault values were removed.

### ⚠️ Behavioral change for review — fallback default → fail-fast

`scripts/deploy-doppler.sh` previously hardcoded a real project name as the fallback default:

```bash
--project "${CRIBL_MCP_DOPPLER_PROJECT:-<hardcoded>}" --config "${CRIBL_MCP_DOPPLER_CONFIG:-prd}"
```

Hardcoding a real project name as a default in a public file is the leak. The default is now removed so the value **must** come from the environment, failing fast if unset:

```bash
--project "${CRIBL_MCP_DOPPLER_PROJECT:?CRIBL_MCP_DOPPLER_PROJECT must be set}" --config "${CRIBL_MCP_DOPPLER_CONFIG:?CRIBL_MCP_DOPPLER_CONFIG must be set}"
```

This matches the existing top-of-`deploy-doppler.sh` guard that already errors when `DOPPLER_PROJECT`/`DOPPLER_CONFIG` are unset. Anyone who was relying on the silent default will now get a clear error instead of a guessed project — intentional.

### Verification

- `grep -rn "iac-conf-mgmt\|cloud-secrets\|GH_ACTION_DOPPLER_IAC_CONF_MGMT"` → no matches.
- `bash -n scripts/deploy-doppler.sh && bash -n scripts/deploy.sh` → passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019whZYTbrt4DnoyXVE5gCF9