### PR TITLE
docs: mark repo decommissioned ahead of archive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 Kubernetes manifests for local OrbStack cluster.
 
+> **⚠️ DECOMMISSIONED (2026-07-08).** The Kubernetes stack is retired and this
+> repo is archived. Monitoring runs in the homelab. The Mac keeps only Cribl
+> Edge, installed directly and run as a non-root user via
+> [nix-darwin](https://github.com/JacobPEvans/nix-darwin)
+> (`modules/darwin/apps/cribl-edge.nix`). The "laptop runs NO Cribl Stream"
+> invariant below is **superseded**: a local Cribl Stream now runs under Apple's
+> native container runtime, also managed by nix-darwin. OrbStack keeps Docker
+> but its Kubernetes is disabled. Everything past this banner is historical.
+
 ## Architecture Invariant
 
 **Edge → homelab Stream → Splunk is the ONLY allowed data path.**

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [![validate](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/validate.yml/badge.svg)](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/validate.yml) [![e2e-tests](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/JacobPEvans/orbstack-kubernetes/actions/workflows/e2e-tests.yml) [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
+> **⚠️ DECOMMISSIONED (2026-07-08).** This local Kubernetes monitoring stack is
+> retired. The monitoring pipeline now runs in the homelab. The only monitoring
+> component that stays on the Mac is Cribl Edge, installed directly and run as a
+> non-root user, managed by
+> [nix-darwin](https://github.com/JacobPEvans/nix-darwin)
+> (`modules/darwin/apps/cribl-edge.nix`). OrbStack keeps Docker, but its
+> Kubernetes is disabled (`orb config set k8s.enable false`). This repo is
+> archived for reference — the manifests below no longer run.
+
 Kubernetes monitoring stack for local OrbStack cluster. Collects, processes, and routes logs from Claude Code, Ollama, terminal sessions, and ephemeral AI containers.
 
 ## Components


### PR DESCRIPTION
Final decommission commit before archiving `dryvist/orbstack-kubernetes`.

## What changed
- Add a **DECOMMISSIONED** banner to `README.md` and `AGENTS.md`.
- Note that the "laptop runs NO Cribl Stream" invariant is superseded — a local Cribl Stream now runs under Apple's native container runtime, managed by nix-darwin.

## Context
The local Kubernetes monitoring stack is retired. The monitoring pipeline runs in the homelab. The Mac keeps only Cribl Edge, installed directly and run as a non-root user via nix-darwin (`modules/darwin/apps/cribl-edge.nix`). OrbStack keeps Docker but its Kubernetes is disabled (`k8s.enable=false`), its RAM cap lowered, and login-autostart turned off — reclaiming resources for local LLM (MLX) work.

No manifests are deleted: archiving preserves them read-only for reference (e.g. the Bifrost config pending homelab relocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)